### PR TITLE
netx, httpx: implement ForceSpecificSNI

### DIFF
--- a/cmd/httpclient/main.go
+++ b/cmd/httpclient/main.go
@@ -39,6 +39,7 @@ import (
 
 var (
 	flagDNSTransport = flag.String("dns-transport", "", "DNS transport to use")
+	flagSNI          = flag.String("sni", "", "Force specific SNI")
 	flagURL          = flag.String("url", "https://ooni.io/", "URL to fetch")
 )
 
@@ -81,7 +82,10 @@ func mainfunc() (err error) {
 		err = errors.New("invalid -dns-transport argument")
 	}
 	if err == nil {
-		fetch(client.HTTPClient, *flagURL)
+		err = client.ForceSpecificSNI(*flagSNI)
+		if err == nil {
+			fetch(client.HTTPClient, *flagURL)
+		}
 	}
 	return
 }

--- a/cmd/httpclient/main.go
+++ b/cmd/httpclient/main.go
@@ -50,10 +50,15 @@ func main() {
 }
 
 func mainfunc() (err error) {
+	defer func() {
+		if recover() != nil {
+			// JUST KNOW WE ARRIVED HERE
+		}
+	}()
 	client := httpx.NewClient(handlers.StdoutHandler)
 	if *common.FlagHelp {
 		flag.CommandLine.SetOutput(os.Stdout)
-		fmt.Printf("Usage: dnsclient [flags]\n")
+		fmt.Printf("Usage: httpclient [flags]\n")
 		flag.PrintDefaults()
 		fmt.Printf("\nExamples:\n")
 		fmt.Printf("%s\n", "  ./httpclient -dns-transport system ...")
@@ -81,19 +86,19 @@ func mainfunc() (err error) {
 	} else if *flagDNSTransport != "" {
 		err = errors.New("invalid -dns-transport argument")
 	}
-	if err == nil {
-		err = client.ForceSpecificSNI(*flagSNI)
-		if err == nil {
-			fetch(client.HTTPClient, *flagURL)
-		}
-	}
+	rtx.PanicOnError(err, "cannot configure DNS transport")
+	err = client.ForceSpecificSNI(*flagSNI)
+	rtx.PanicOnError(err, "cannot force specific SNI")
+	err = fetch(client.HTTPClient, *flagURL)
+	rtx.PanicOnError(err, "cannot fetch specific URL")
 	return
 }
 
-func fetch(client *http.Client, url string) {
+func fetch(client *http.Client, url string) (err error) {
 	resp, err := client.Get(url)
 	if err == nil {
-		ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
+		defer resp.Body.Close()
+		_, err = ioutil.ReadAll(resp.Body)
 	}
+	return
 }

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -59,6 +59,11 @@ func (t *Transport) SetCABundle(path string) error {
 	return t.dialer.SetCABundle(path)
 }
 
+// ForceSpecificSNI forces using a specific SNI.
+func (t *Transport) ForceSpecificSNI(sni string) error {
+	return t.dialer.ForceSpecificSNI(sni)
+}
+
 // Client is a replacement for http.Client.
 type Client struct {
 	// HTTPClient is the underlying client. Pass this client to existing code
@@ -91,4 +96,9 @@ func (c *Client) ConfigureDNS(network, address string) error {
 // therefore it has the same caveats and limitations.
 func (c *Client) SetCABundle(path string) error {
 	return c.Transport.SetCABundle(path)
+}
+
+// ForceSpecificSNI forces using a specific SNI.
+func (c *Client) ForceSpecificSNI(sni string) error {
+	return c.Transport.ForceSpecificSNI(sni)
 }

--- a/httpx/httpx_test.go
+++ b/httpx/httpx_test.go
@@ -33,3 +33,21 @@ func TestSetCABundle(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestForceSpecificSNI(t *testing.T) {
+	client := httpx.NewClient(handlers.NoHandler)
+	err := client.ForceSpecificSNI("www.facebook.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.HTTPClient.Get("https://www.google.com")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	// TODO(bassosimone): how to unwrap the error in Go < 1.13? Anyway we are
+	// already testing we're getting the right error in netx_test.go.
+	t.Log(err)
+	if resp != nil {
+		t.Fatal("expected a nil response here")
+	}
+}

--- a/internal/dialerapi/dialerapi.go
+++ b/internal/dialerapi/dialerapi.go
@@ -229,3 +229,9 @@ func (d *Dialer) SetCABundle(path string) error {
 	d.TLSConfig.RootCAs = pool
 	return nil
 }
+
+// ForceSpecificSNI forces using a specific SNI.
+func (d *Dialer) ForceSpecificSNI(sni string) error {
+	d.TLSConfig.ServerName = sni
+	return nil
+}

--- a/internal/dialerapi/dialerapi_test.go
+++ b/internal/dialerapi/dialerapi_test.go
@@ -206,3 +206,18 @@ func TestSetCABundleWAI(t *testing.T) {
 		t.Fatal("expected a nil conn here")
 	}
 }
+
+func TestForceSpecificSNI(t *testing.T) {
+	dialer := dialerapi.NewDialer(time.Now(), handlers.NoHandler)
+	err := dialer.ForceSpecificSNI("www.facebook.com")
+	conn, err := dialer.DialTLS("tcp", "www.google.com:443")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if _, ok := err.(x509.HostnameError); !ok {
+		t.Fatal("not the error we expected")
+	}
+	if conn != nil {
+		t.Fatal("expected a nil connection here")
+	}
+}

--- a/netx.go
+++ b/netx.go
@@ -113,3 +113,8 @@ func (d *Dialer) NewResolver(network, address string) (dnsx.Client, error) {
 func (d *Dialer) SetCABundle(path string) error {
 	return d.dialer.SetCABundle(path)
 }
+
+// ForceSpecificSNI forces using a specific SNI.
+func (d *Dialer) ForceSpecificSNI(sni string) error {
+	return d.dialer.ForceSpecificSNI(sni)
+}

--- a/netx_test.go
+++ b/netx_test.go
@@ -2,6 +2,7 @@ package netx_test
 
 import (
 	"context"
+	"crypto/x509"
 	"testing"
 
 	"github.com/ooni/netx"
@@ -53,5 +54,23 @@ func TestSetCABundle(t *testing.T) {
 	err := dialer.SetCABundle("testdata/cacert.pem")
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestForceSpecificSNI(t *testing.T) {
+	dialer := netx.NewDialer(handlers.NoHandler)
+	err := dialer.ForceSpecificSNI("www.facebook.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := dialer.DialTLS("tcp", "www.google.com:443")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if _, ok := err.(x509.HostnameError); !ok {
+		t.Fatal("not the error we expected")
+	}
+	if conn != nil {
+		t.Fatal("expected nil conn here")
 	}
 }


### PR DESCRIPTION
This is a necessary building block for measuring SNI based
blocking inside a specific network.

Closes #8