### PR TITLE
dnsoverhttps.go: decouple from netx/httpx

### DIFF
--- a/internal/dnsconf/dnsconf.go
+++ b/internal/dnsconf/dnsconf.go
@@ -31,8 +31,11 @@ func ConfigureDNS(dialer *dialerapi.Dialer, network, address string) error {
 func newHTTPClientForDoH(beginning time.Time, handler model.Handler) *http.Client {
 	dialer := dialerapi.NewDialer(beginning, handler)
 	transport := httptransport.NewTransport(dialer.Beginning, dialer.Handler)
-	// Logic to make sure we'll use the dialer in the new HTTP transport
+	// Logic to make sure we'll use the dialer in the new HTTP transport. We have
+	// an already well configured config that works for http2 (as explained in a
+	// comment there). Here we just use it because it's what we need.
 	dialer.TLSConfig = transport.TLSClientConfig
+	// Arrange the configuration such that we always use `dialer` for dialing.
 	transport.Dial = dialer.Dial
 	transport.DialContext = dialer.DialContext
 	transport.DialTLS = dialer.DialTLS

--- a/internal/dnsconf/dnsconf.go
+++ b/internal/dnsconf/dnsconf.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/http"
+	"time"
 
 	"github.com/ooni/netx/dnsx"
 	"github.com/ooni/netx/internal/connx"
@@ -13,6 +15,8 @@ import (
 	"github.com/ooni/netx/internal/dnstransport/dnsovertcp"
 	"github.com/ooni/netx/internal/dnstransport/dnsoverudp"
 	"github.com/ooni/netx/internal/godns"
+	"github.com/ooni/netx/internal/httptransport"
+	"github.com/ooni/netx/model"
 )
 
 // ConfigureDNS implements netx.Dialer.ConfigureDNS.
@@ -22,6 +26,18 @@ func ConfigureDNS(dialer *dialerapi.Dialer, network, address string) error {
 		dialer.LookupHost = r.LookupHost
 	}
 	return err
+}
+
+func newHTTPClientForDoH(beginning time.Time, handler model.Handler) *http.Client {
+	dialer := dialerapi.NewDialer(beginning, handler)
+	transport := httptransport.NewTransport(dialer.Beginning, dialer.Handler)
+	// Logic to make sure we'll use the dialer in the new HTTP transport
+	dialer.TLSConfig = transport.TLSClientConfig
+	transport.Dial = dialer.Dial
+	transport.DialContext = dialer.DialContext
+	transport.DialTLS = dialer.DialTLS
+	transport.MaxConnsPerHost = 1 // seems to be better for cloudflare DNS
+	return &http.Client{Transport: transport}
 }
 
 // NewResolver returns a new resolver using this Dialer as dialer for
@@ -55,7 +71,7 @@ func NewResolver(
 	var transport dnsx.RoundTripper
 	if network == "doh" {
 		transport = dnsoverhttps.NewTransport(
-			dialer.Beginning, dialer.Handler, address,
+			newHTTPClientForDoH(dialer.Beginning, dialer.Handler), address,
 		)
 	} else if network == "dot" {
 		host, port, err := net.SplitHostPort(address)

--- a/internal/dnstransport/dnsoverhttps/dnsoverhttps.go
+++ b/internal/dnstransport/dnsoverhttps/dnsoverhttps.go
@@ -6,11 +6,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"time"
-
-	"github.com/ooni/netx/internal/dialerapi"
-	"github.com/ooni/netx/internal/httptransport"
-	"github.com/ooni/netx/model"
 )
 
 // Transport is a DNS over HTTPS dnsx.RoundTripper.
@@ -18,50 +13,33 @@ import (
 // As a known bug, this implementation does not cache the domain
 // name in the URL for reuse, but this should be easy to fix.
 type Transport struct {
-	// Client is the HTTP client to use.
-	Client *http.Client
-
-	// ClientDo allows to override the Client.Do behaviour. This is
-	// initialized in NewTransport to call Client.Do.
-	ClientDo func(req *http.Request) (*http.Response, error)
-
-	// URL is the DoH server URL.
-	URL string
+	clientDo func(req *http.Request) (*http.Response, error)
+	url      string
 }
 
 // NewTransport creates a new Transport
-func NewTransport(beginning time.Time, handler model.Handler, URL string) *Transport {
-	dialer := dialerapi.NewDialer(beginning, handler)
-	transport := httptransport.NewTransport(dialer.Beginning, dialer.Handler)
-	// Logic to make sure we'll use the dialer in the new HTTP transport
-	dialer.TLSConfig = transport.TLSClientConfig
-	transport.Dial = dialer.Dial
-	transport.DialContext = dialer.DialContext
-	transport.DialTLS = dialer.DialTLS
-	transport.MaxConnsPerHost = 1 // seems to be better for cloudflare DNS
-	client := &http.Client{Transport: transport}
+func NewTransport(client *http.Client, URL string) *Transport {
 	return &Transport{
-		Client:   client,
-		ClientDo: client.Do,
-		URL:      URL,
+		clientDo: client.Do,
+		url:      URL,
 	}
 }
 
 // RoundTrip sends a request and receives a response.
 func (t *Transport) RoundTrip(query []byte) (reply []byte, err error) {
-	req, err := http.NewRequest("POST", t.URL, bytes.NewReader(query))
+	req, err := http.NewRequest("POST", t.url, bytes.NewReader(query))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("content-type", "application/dns-message")
 	var resp *http.Response
-	resp, err = t.ClientDo(req)
+	resp, err = t.clientDo(req)
 	if err != nil {
 		return
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		// TODO(ooni): we should map the status code to a
+		// TODO(bassosimone): we should map the status code to a
 		// proper Error in the DNS context.
 		err = errors.New("doh: server returned error")
 		return

--- a/internal/godns/godns_test.go
+++ b/internal/godns/godns_test.go
@@ -2,6 +2,7 @@ package godns_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -13,8 +14,7 @@ import (
 func TestIntegrationSuccess(t *testing.T) {
 	start := time.Now()
 	transport := dnsoverhttps.NewTransport(
-		start, handlers.NoHandler,
-		"https://cloudflare-dns.com/dns-query",
+		http.DefaultClient, "https://cloudflare-dns.com/dns-query",
 	)
 	client := godns.NewClient(start, handlers.NoHandler, transport)
 	addrs, err := client.LookupHost(context.Background(), "ooni.io")
@@ -29,8 +29,7 @@ func TestIntegrationSuccess(t *testing.T) {
 func TestIntegrationReadWithTimeout(t *testing.T) {
 	start := time.Now()
 	transport := dnsoverhttps.NewTransport(
-		start, handlers.NoHandler,
-		"https://cloudflare-dns.com/dns-query",
+		http.DefaultClient, "https://cloudflare-dns.com/dns-query",
 	)
 	conn := godns.NewPseudoConn(start, handlers.NoHandler, transport)
 	err := conn.SetDeadline(time.Now()) // very short deadline


### PR DESCRIPTION
We can implement the full DoH transport without using any specific
structure of netx/httxp, which is great because it allows us to reduce
the coupling with otherwise unrelated parts of the tree.

This is again from-the-yak-shaving dept.