### PR TITLE
dnsovertcp: decouple from netx/httpx

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -433,7 +433,9 @@ such as `Read` and `Write` events. We will also be able to
 record the DNS messages sent and received.
 
 * when `network` is `"udp"`, `address` must be a valid
-string following the `"<ip>:<port>"` pattern. This will
+string following the `"<ip_or_domain>(:<port>)*"` pattern. If
+`<ip_or_domain>` is IPv6, it must be quoted using `[]`. If
+`<port>` is omitted, we will use port `53`. This value will
 indicate the code to use the selected DNS server using
 UDP transport. We will be able to observe all events including
 DNS messages sent and received.
@@ -443,7 +445,8 @@ DNS messages sent and received.
 over TCP protocol with the configured server.
 
 * when `network` is `"dot"`, `address` must be a valid
-domain name of a DNS over TLS server to use. We will
+domain name, or IP address, of a DNS over TLS server to use. If
+the port is omitted, we'll use port `853`. We will
 observe all events, which of course include the results
 of the TLS handshake with the server, the DNS messages
 sent and received, etc.

--- a/internal/dnsconf/dnsconf_test.go
+++ b/internal/dnsconf/dnsconf_test.go
@@ -6,85 +6,104 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ooni/netx/dnsx"
 	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/internal/connx"
 	"github.com/ooni/netx/internal/dialerapi"
 	"github.com/ooni/netx/internal/dnsconf"
 )
 
-func TestIntegrationNewResolver(t *testing.T) {
+func testresolverquick(t *testing.T, network, address string) {
+	var resolver dnsx.Client
+	d := dialerapi.NewDialer(time.Now(), handlers.NoHandler)
+	resolver, err := dnsconf.NewResolver(d, network, address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolver == nil {
+		t.Fatal("expected non-nil resolver here")
+	}
+	addrs, err := resolver.LookupHost(context.Background(), "dns.google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addrs == nil {
+		t.Fatal("expected non-nil addrs here")
+	}
+	var foundquad8 bool
+	for _, addr := range addrs {
+		if addr == "8.8.8.8" {
+			foundquad8 = true
+		}
+	}
+	if !foundquad8 {
+		t.Fatal("did not find 8.8.8.8 in ouput")
+	}
+}
+
+func TestIntegrationNewResolverUDPAddress(t *testing.T) {
+	testresolverquick(t, "udp", "8.8.8.8:53")
+}
+
+func TestIntegrationNewResolverUDPAddressNoPort(t *testing.T) {
+	testresolverquick(t, "udp", "8.8.8.8")
+}
+
+func TestIntegrationNewResolverUDPDomain(t *testing.T) {
+	testresolverquick(t, "udp", "dns.google.com:53")
+}
+
+func TestIntegrationNewResolverUDPDomainNoPort(t *testing.T) {
+	testresolverquick(t, "udp", "dns.google.com")
+}
+
+func TestIntegrationNewResolverSystem(t *testing.T) {
+	testresolverquick(t, "system", "")
+}
+
+func TestIntegrationNewResolverGoDNS(t *testing.T) {
+	testresolverquick(t, "godns", "")
+}
+
+func TestIntegrationNewResolverTCPAddress(t *testing.T) {
+	testresolverquick(t, "tcp", "8.8.8.8:53")
+}
+
+func TestIntegrationNewResolverTCPAddressNoPort(t *testing.T) {
+	testresolverquick(t, "tcp", "8.8.8.8")
+}
+
+func TestIntegrationNewResolverTCPDomain(t *testing.T) {
+	testresolverquick(t, "tcp", "dns.google.com:53")
+}
+
+func TestIntegrationNewResolverTCPDomainNoPort(t *testing.T) {
+	testresolverquick(t, "tcp", "dns.google.com")
+}
+
+func TestIntegrationNewResolverDoTAddress(t *testing.T) {
+	testresolverquick(t, "dot", "9.9.9.9:853")
+}
+
+func TestIntegrationNewResolverDoTAddressNoPort(t *testing.T) {
+	testresolverquick(t, "dot", "9.9.9.9")
+}
+
+func TestIntegrationNewResolverDoTDomain(t *testing.T) {
+	testresolverquick(t, "dot", "dns.quad9.net:853")
+}
+
+func TestIntegrationNewResolverDoTDomainNoPort(t *testing.T) {
+	testresolverquick(t, "dot", "dns.quad9.net")
+}
+
+func TestIntegrationNewResolverDoH(t *testing.T) {
+	testresolverquick(t, "doh", "https://cloudflare-dns.com/dns-query")
+}
+
+func TestIntegrationNewResolverInvalid(t *testing.T) {
 	d := dialerapi.NewDialer(time.Now(), handlers.NoHandler)
 	resolver, err := dnsconf.NewResolver(
-		d, "udp", "8.8.8.8:53",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resolver == nil {
-		t.Fatal("expected non-nil resolver here")
-	}
-
-	resolver, err = dnsconf.NewResolver(
-		d, "system", "",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resolver == nil {
-		t.Fatal("expected non-nil resolver here")
-	}
-
-	resolver, err = dnsconf.NewResolver(
-		d, "godns", "",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resolver == nil {
-		t.Fatal("expected non-nil resolver here")
-	}
-
-	resolver, err = dnsconf.NewResolver(
-		d, "tcp", "8.8.8.8:53",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resolver == nil {
-		t.Fatal("expected non-nil resolver here")
-	}
-
-	resolver, err = dnsconf.NewResolver(
-		d, "dot", "dns.quad9.net",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resolver == nil {
-		t.Fatal("expected non-nil resolver here")
-	}
-
-	resolver, err = dnsconf.NewResolver(
-		d, "dot", "1.1.1.1:853",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resolver == nil {
-		t.Fatal("expected non-nil resolver here")
-	}
-
-	resolver, err = dnsconf.NewResolver(
-		d, "doh", "https://cloudflare-dns.com/dns-query",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resolver == nil {
-		t.Fatal("expected non-nil resolver here")
-	}
-
-	resolver, err = dnsconf.NewResolver(
 		d, "antani", "https://cloudflare-dns.com/dns-query",
 	)
 	if err == nil {
@@ -95,48 +114,23 @@ func TestIntegrationNewResolver(t *testing.T) {
 	}
 }
 
-func TestIntegrationNewResolverBadTCPEndpoint(t *testing.T) {
+func testconfigurednsquick(t *testing.T, network, address string) {
 	d := dialerapi.NewDialer(time.Now(), handlers.NoHandler)
-	resolver, err := dnsconf.NewResolver(
-		d, "tcp", "8.8.8.8",
-	)
-	if err == nil {
-		t.Fatal("expected an error here")
-	}
-	if resolver != nil {
-		t.Fatal("expected a nil resolver here")
-	}
-}
-
-func TestIntegrationDo(t *testing.T) {
-	d := dialerapi.NewDialer(time.Now(), handlers.NoHandler)
-	err := dnsconf.ConfigureDNS(d, "dot", "dns.quad9.net")
+	err := dnsconf.ConfigureDNS(d, network, address)
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-func TestIntegrationGoDNSResolverSuccess(t *testing.T) {
-	d := dialerapi.NewDialer(time.Now(), handlers.NoHandler)
-	resolver, err := dnsconf.NewResolver(
-		d, "godns", "",
-	)
+	conn, err := d.DialTLS("tcp", "www.google.com:443")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resolver == nil {
-		t.Fatal("expected non-nil resolver here")
+	if conn == nil {
+		t.Fatal("expected non-nil conn here")
 	}
-	addrs, err := resolver.LookupHost(context.Background(), "www.google.com")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(addrs) < 1 {
-		t.Fatal("expected non empty addrs here")
-	}
+	conn.Close()
 }
 
-func TestIntegrationGoDNSResolverFailure(t *testing.T) {
+func TestGoDNSDialContextExFailure(t *testing.T) {
 	d := dialerapi.NewDialer(time.Now(), handlers.NoHandler)
 	resolver, err := dnsconf.NewResolver(
 		d, "godns", "",
@@ -162,4 +156,8 @@ func TestIntegrationGoDNSResolverFailure(t *testing.T) {
 	if len(addrs) != 0 {
 		t.Fatal("expected empty addrs here")
 	}
+}
+
+func TestIntegrationConfigureDNSGoDNS(t *testing.T) {
+	testconfigurednsquick(t, "godns", "")
 }

--- a/internal/dnsconf/dnsconf_test.go
+++ b/internal/dnsconf/dnsconf_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ooni/netx/dnsx"
 	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/internal/connx"
 	"github.com/ooni/netx/internal/dialerapi"
@@ -14,7 +13,6 @@ import (
 )
 
 func testresolverquick(t *testing.T, network, address string) {
-	var resolver dnsx.Client
 	d := dialerapi.NewDialer(time.Now(), handlers.NoHandler)
 	resolver, err := dnsconf.NewResolver(d, network, address)
 	if err != nil {

--- a/internal/dnstransport/dnsovertcp/dnsovertcp.go
+++ b/internal/dnstransport/dnsovertcp/dnsovertcp.go
@@ -4,15 +4,11 @@ package dnsovertcp
 
 import (
 	"bufio"
-	"errors"
 	"io"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/m-lab/go/rtx"
-	"github.com/ooni/netx/internal/dialerapi"
-	"github.com/ooni/netx/model"
 )
 
 // Transport is a DNS over TCP/TLS dnsx.RoundTripper.
@@ -20,101 +16,24 @@ import (
 // As a known bug, this implementation always creates a new connection
 // for each incoming query, thus increasing the response delay.
 type Transport struct {
-	// Dialer is the dialer to use.
-	Dialer *dialerapi.Dialer
-
-	// Hostname is the hostname of the service.
-	Hostname string
-
-	// LookupHost allows you to override the code used to lookup
-	// the address of the DoT server domain name.
-	LookupHost func(host string) (addrs []string, err error)
-
-	// NoTLS indicates that we don't want to use TLS.
-	NoTLS bool
-
-	// Port is the port of the service.
-	Port string
-
-	// address is the resolved address of the service.
+	dial    func(network, address string) (net.Conn, error)
 	address string
-
-	// init indicates whether we've initialized
-	init bool
-
-	// mutex makes initialize idempotent.
-	mutex sync.Mutex
 }
 
 // NewTransport creates a new Transport
-func NewTransport(beginning time.Time, handler model.Handler, hostname string) *Transport {
-	dialer := dialerapi.NewDialer(beginning, handler)
+func NewTransport(
+	dial func(network, address string) (net.Conn, error),
+	address string,
+) *Transport {
 	return &Transport{
-		Dialer:   dialer,
-		Hostname: hostname,
+		dial:    dial,
+		address: address,
 	}
-}
-
-func (t *Transport) initUnlocked() (err error) {
-	if t.LookupHost == nil {
-		t.LookupHost = net.LookupHost
-	}
-	if t.address == "" {
-		if net.ParseIP(t.Hostname) == nil {
-			var addrs []string
-			addrs, err = t.LookupHost(t.Hostname)
-			if err != nil {
-				return err
-			}
-			if len(addrs) < 1 {
-				return errors.New("dnsovertcp: net.LookupHost: empty reply")
-			}
-			t.address = addrs[0]
-		} else {
-			t.address = t.Hostname
-		}
-	}
-	if t.NoTLS == false {
-		if t.Port == "" {
-			t.Port = "853"
-		}
-		t.Dialer.TLSConfig = t.Dialer.TLSConfig.Clone()
-		t.Dialer.TLSConfig.ServerName = t.Hostname
-	} else if t.Port == "" {
-		t.Port = "53"
-	}
-	return nil
-}
-
-func (t *Transport) initialize() (err error) {
-	t.mutex.Lock()
-	if !t.init {
-		t.init = true
-		err = t.initUnlocked()
-	}
-	t.mutex.Unlock()
-	return
 }
 
 // RoundTrip sends a request and receives a response.
 func (t *Transport) RoundTrip(query []byte) ([]byte, error) {
-	var (
-		conn net.Conn
-		err  error
-	)
-	err = t.initialize()
-	if err != nil {
-		return nil, err
-	}
-	if t.NoTLS == false {
-		conn, err = t.Dialer.DialTLS(
-			"tcp", net.JoinHostPort(t.address, t.Port),
-		)
-	} else {
-		conn, err = t.Dialer.Dial(
-			"tcp", net.JoinHostPort(t.address, t.Port),
-		)
-	}
+	conn, err := t.dial("tcp", t.address)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dnstransport/dnsoverudp/dnsoverudp.go
+++ b/internal/dnstransport/dnsoverudp/dnsoverudp.go
@@ -2,7 +2,6 @@
 package dnsoverudp
 
 import (
-	"errors"
 	"net"
 	"time"
 )
@@ -26,16 +25,7 @@ func NewTransport(
 
 // RoundTrip sends a request and receives a response.
 func (t *Transport) RoundTrip(query []byte) (reply []byte, err error) {
-	address, _, err := net.SplitHostPort(t.address)
-	if err != nil {
-		return
-	}
-	if net.ParseIP(address) == nil {
-		err = errors.New("dnsoverudp: d.address is not IPv4/IPv6")
-		return
-	}
-	var conn net.Conn
-	conn, err = t.dial("udp", t.address)
+	conn, err := t.dial("udp", t.address)
 	if err != nil {
 		return
 	}

--- a/internal/dnstransport/dnsoverudp/dnsoverudp_test.go
+++ b/internal/dnstransport/dnsoverudp/dnsoverudp_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ooni/netx/internal/connx"
 )
 
-func TestIntegrationSuccess(t *testing.T) {
+func TestIntegrationSuccessWithAddress(t *testing.T) {
 	transport := NewTransport(
 		net.Dial, "9.9.9.9:53",
 	)
@@ -21,23 +21,13 @@ func TestIntegrationSuccess(t *testing.T) {
 	}
 }
 
-func TestIntegrationSplitHostPortFailure(t *testing.T) {
+func TestIntegrationSuccessWithDomain(t *testing.T) {
 	transport := NewTransport(
-		net.Dial, "antani",
+		net.Dial, "dns.quad9.net:53",
 	)
 	err := threeRounds(transport)
-	if err == nil {
-		t.Fatal("expected an error here")
-	}
-}
-
-func TestIntegrationParseIPFailure(t *testing.T) {
-	transport := NewTransport(
-		net.Dial, "antani:53",
-	)
-	err := threeRounds(transport)
-	if err == nil {
-		t.Fatal("expected an error here")
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/oodns/oodns_test.go
+++ b/internal/oodns/oodns_test.go
@@ -2,9 +2,10 @@ package oodns_test
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
+	"net"
 	"testing"
-	"time"
 
 	"github.com/miekg/dns"
 	"github.com/ooni/netx/dnsx"
@@ -13,11 +14,18 @@ import (
 	"github.com/ooni/netx/internal/oodns"
 )
 
+func newtransport() dnsx.RoundTripper {
+	return dnsovertcp.NewTransport(
+		func(network, address string) (net.Conn, error) {
+			return tls.Dial(network, address, nil)
+		},
+		"dns.quad9.net:853",
+	)
+}
+
 func TestLookupAddr(t *testing.T) {
 	client := oodns.NewClient(
-		handlers.NoHandler, dnsovertcp.NewTransport(
-			time.Now(), handlers.NoHandler, "dns.quad9.net",
-		),
+		handlers.NoHandler, newtransport(),
 	)
 	addrs, err := client.LookupAddr(context.Background(), "130.192.91.211")
 	if err == nil {
@@ -30,9 +38,7 @@ func TestLookupAddr(t *testing.T) {
 
 func TestLookupCNAME(t *testing.T) {
 	client := oodns.NewClient(
-		handlers.NoHandler, dnsovertcp.NewTransport(
-			time.Now(), handlers.NoHandler, "dns.quad9.net",
-		),
+		handlers.NoHandler, newtransport(),
 	)
 	addrs, err := client.LookupCNAME(context.Background(), "www.ooni.io")
 	if err == nil {
@@ -45,9 +51,7 @@ func TestLookupCNAME(t *testing.T) {
 
 func TestLookupHost(t *testing.T) {
 	client := oodns.NewClient(
-		handlers.NoHandler, dnsovertcp.NewTransport(
-			time.Now(), handlers.NoHandler, "dns.quad9.net",
-		),
+		handlers.NoHandler, newtransport(),
 	)
 	addrs, err := client.LookupHost(context.Background(), "www.google.com")
 	if err != nil {
@@ -60,9 +64,7 @@ func TestLookupHost(t *testing.T) {
 
 func TestLookupNonexistent(t *testing.T) {
 	client := oodns.NewClient(
-		handlers.NoHandler, dnsovertcp.NewTransport(
-			time.Now(), handlers.NoHandler, "dns.quad9.net",
-		),
+		handlers.NoHandler, newtransport(),
 	)
 	addrs, err := client.LookupHost(context.Background(), "nonexistent.ooni.io")
 	if err == nil {
@@ -75,9 +77,7 @@ func TestLookupNonexistent(t *testing.T) {
 
 func TestLookupMX(t *testing.T) {
 	client := oodns.NewClient(
-		handlers.NoHandler, dnsovertcp.NewTransport(
-			time.Now(), handlers.NoHandler, "dns.quad9.net",
-		),
+		handlers.NoHandler, newtransport(),
 	)
 	addrs, err := client.LookupMX(context.Background(), "ooni.io")
 	if err == nil {
@@ -90,9 +90,7 @@ func TestLookupMX(t *testing.T) {
 
 func TestLookupNS(t *testing.T) {
 	client := oodns.NewClient(
-		handlers.NoHandler, dnsovertcp.NewTransport(
-			time.Now(), handlers.NoHandler, "dns.quad9.net",
-		),
+		handlers.NoHandler, newtransport(),
 	)
 	addrs, err := client.LookupNS(context.Background(), "ooni.io")
 	if err == nil {
@@ -105,9 +103,7 @@ func TestLookupNS(t *testing.T) {
 
 func TestRoundTripExPackFailure(t *testing.T) {
 	client := oodns.NewClient(
-		handlers.NoHandler, dnsovertcp.NewTransport(
-			time.Now(), handlers.NoHandler, "dns.quad9.net",
-		),
+		handlers.NoHandler, newtransport(),
 	)
 	_, err := client.RoundTripEx(
 		context.Background(), nil,
@@ -128,9 +124,7 @@ func TestRoundTripExPackFailure(t *testing.T) {
 
 func TestRoundTripExRoundTripFailure(t *testing.T) {
 	client := oodns.NewClient(
-		handlers.NoHandler, dnsovertcp.NewTransport(
-			time.Now(), handlers.NoHandler, "dns.quad9.net",
-		),
+		handlers.NoHandler, newtransport(),
 	)
 	_, err := client.RoundTripEx(
 		context.Background(), nil,
@@ -151,9 +145,7 @@ func TestRoundTripExRoundTripFailure(t *testing.T) {
 
 func TestRoundTripExUnpackFailure(t *testing.T) {
 	client := oodns.NewClient(
-		handlers.NoHandler, dnsovertcp.NewTransport(
-			time.Now(), handlers.NoHandler, "dns.quad9.net",
-		),
+		handlers.NoHandler, newtransport(),
 	)
 	_, err := client.RoundTripEx(
 		context.Background(), nil,


### PR DESCRIPTION
Same purpose of #28 and #27. We want to reach a situation where we can
construct a DNS transport that does not depend on netx/httpx.

The general objective here is (1) to decouple unrelated parts of the
tree and (2) to use dependency injection to enable writing wrappers for
any piece of code, so to enable follow-up measurements when any step
we're performing seems to return something fishy.

While working on this diff, I noticed that there was inconsistency
in the way in which we manage DNS:

- some resolvers tolerated domain input, others did not

- some resolvers automatically added ports in some cases

I've therefore made sure all resolvers are constructed in a way that
is robust to supplying DNS names as well as to missing ports.