### PR TITLE
[API CHANGE] Pass context to dns RoundTripper

### DIFF
--- a/dnsx/dnsx.go
+++ b/dnsx/dnsx.go
@@ -28,5 +28,5 @@ type Client interface {
 // RoundTripper represents an abstract DNS transport.
 type RoundTripper interface {
 	// RoundTrip sends a DNS query and receives the reply.
-	RoundTrip(query []byte) (reply []byte, err error)
+	RoundTrip(ctx context.Context, query []byte) (reply []byte, err error)
 }

--- a/internal/dnstransport/dnsoverhttps/dnsoverhttps.go
+++ b/internal/dnstransport/dnsoverhttps/dnsoverhttps.go
@@ -2,6 +2,7 @@
 package dnsoverhttps
 
 import (
+	"context"
 	"bytes"
 	"errors"
 	"io/ioutil"
@@ -26,14 +27,14 @@ func NewTransport(client *http.Client, URL string) *Transport {
 }
 
 // RoundTrip sends a request and receives a response.
-func (t *Transport) RoundTrip(query []byte) (reply []byte, err error) {
+func (t *Transport) RoundTrip(ctx context.Context, query []byte) (reply []byte, err error) {
 	req, err := http.NewRequest("POST", t.url, bytes.NewReader(query))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("content-type", "application/dns-message")
 	var resp *http.Response
-	resp, err = t.clientDo(req)
+	resp, err = t.clientDo(req.WithContext(ctx))
 	if err != nil {
 		return
 	}

--- a/internal/dnstransport/dnsoverhttps/dnsoverhttps_test.go
+++ b/internal/dnstransport/dnsoverhttps/dnsoverhttps_test.go
@@ -1,6 +1,7 @@
 package dnsoverhttps
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -98,7 +99,7 @@ func roundTrip(transport *Transport, domain string) error {
 	if err != nil {
 		return err
 	}
-	data, err = transport.RoundTrip(data)
+	data, err = transport.RoundTrip(context.Background(), data)
 	if err != nil {
 		return err
 	}

--- a/internal/dnstransport/dnsovertcp/dnsovertcp.go
+++ b/internal/dnstransport/dnsovertcp/dnsovertcp.go
@@ -4,6 +4,7 @@ package dnsovertcp
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net"
 	"time"
@@ -32,7 +33,7 @@ func NewTransport(
 }
 
 // RoundTrip sends a request and receives a response.
-func (t *Transport) RoundTrip(query []byte) ([]byte, error) {
+func (t *Transport) RoundTrip(ctx context.Context, query []byte) ([]byte, error) {
 	conn, err := t.dial("tcp", t.address)
 	if err != nil {
 		return nil, err

--- a/internal/dnstransport/dnsovertcp/dnsovertcp_test.go
+++ b/internal/dnstransport/dnsovertcp/dnsovertcp_test.go
@@ -1,6 +1,7 @@
 package dnsovertcp
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"net"
@@ -92,7 +93,7 @@ func roundTrip(transport *Transport, domain string) error {
 	if err != nil {
 		return err
 	}
-	data, err = transport.RoundTrip(data)
+	data, err = transport.RoundTrip(context.Background(), data)
 	if err != nil {
 		return err
 	}

--- a/internal/dnstransport/dnsoverudp/dnsoverudp.go
+++ b/internal/dnstransport/dnsoverudp/dnsoverudp.go
@@ -2,6 +2,7 @@
 package dnsoverudp
 
 import (
+	"context"
 	"net"
 	"time"
 )
@@ -24,7 +25,7 @@ func NewTransport(
 }
 
 // RoundTrip sends a request and receives a response.
-func (t *Transport) RoundTrip(query []byte) (reply []byte, err error) {
+func (t *Transport) RoundTrip(ctx context.Context, query []byte) (reply []byte, err error) {
 	conn, err := t.dial("udp", t.address)
 	if err != nil {
 		return

--- a/internal/dnstransport/dnsoverudp/dnsoverudp_test.go
+++ b/internal/dnstransport/dnsoverudp/dnsoverudp_test.go
@@ -1,6 +1,7 @@
 package dnsoverudp
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
@@ -103,7 +104,7 @@ func roundTrip(transport *Transport, domain string) error {
 	if err != nil {
 		return err
 	}
-	data, err = transport.RoundTrip(data)
+	data, err = transport.RoundTrip(context.Background(), data)
 	if err != nil {
 		return err
 	}

--- a/internal/godns/godns.go
+++ b/internal/godns/godns.go
@@ -192,6 +192,6 @@ func (c *pseudoConn) lookup(b []byte) {
 }
 
 func (c *pseudoConn) do(query []byte) (r godnsResult) {
-	r.reply, r.err = c.t.RoundTrip(query)
+	r.reply, r.err = c.t.RoundTrip(context.Background(), query)
 	return r
 }

--- a/internal/oodns/oodns.go
+++ b/internal/oodns/oodns.go
@@ -125,7 +125,9 @@ func (c *Client) roundTrip(ctx context.Context, query *dns.Msg) (reply *dns.Msg,
 			return msg.Pack()
 		},
 		func(t dnsx.RoundTripper, query []byte) (reply []byte, err error) {
-			return t.RoundTrip(query)
+			// Pass ctx to round tripper for cancellation as well
+			// as to propagate context information
+			return t.RoundTrip(ctx, query)
 		},
 		func(msg *dns.Msg, data []byte) (err error) {
 			return msg.Unpack(data)


### PR DESCRIPTION
This is required to pass along cancellation information, where this
is possible, as well as information on what we're doing.