### PR TITLE
Move relevant DNS interfaces in model

### DIFF
--- a/cmd/dnsclient/main.go
+++ b/cmd/dnsclient/main.go
@@ -38,8 +38,8 @@ import (
 	"github.com/m-lab/go/rtx"
 	"github.com/ooni/netx"
 	"github.com/ooni/netx/cmd/common"
-	"github.com/ooni/netx/dnsx"
 	"github.com/ooni/netx/handlers"
+	"github.com/ooni/netx/model"
 )
 
 var (
@@ -58,7 +58,7 @@ func mainWithContext(ctx context.Context) error {
 		mxrecs   []*net.MX
 		names    []string
 		nsrecs   []*net.NS
-		resolver dnsx.Client
+		resolver model.DNSResolver
 	)
 	if *common.FlagHelp {
 		flag.CommandLine.SetOutput(os.Stdout)

--- a/dnsx/dnsx.go
+++ b/dnsx/dnsx.go
@@ -1,32 +1,10 @@
 // Package dnsx contains OONI's DNS extensions
 package dnsx
 
-import (
-	"context"
-	"net"
-)
+import "github.com/ooni/netx/model"
 
-// Client is a DNS client. The *net.Resolver used by Go implements
-// this interface, but other implementations are possible.
-type Client interface {
-	// LookupAddr performs a reverse lookup of an address.
-	LookupAddr(ctx context.Context, addr string) (names []string, err error)
+// Client is the old name for model.DNSResolver.
+type Client model.DNSResolver
 
-	// LookupCNAME returns the canonical name of a given host.
-	LookupCNAME(ctx context.Context, host string) (cname string, err error)
-
-	// LookupHost resolves a hostname to a list of IP addresses.
-	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
-
-	// LookupMX resolves the DNS MX records for a given domain name.
-	LookupMX(ctx context.Context, name string) ([]*net.MX, error)
-
-	// LookupNS resolves the DNS NS records for a given domain name.
-	LookupNS(ctx context.Context, name string) ([]*net.NS, error)
-}
-
-// RoundTripper represents an abstract DNS transport.
-type RoundTripper interface {
-	// RoundTrip sends a DNS query and receives the reply.
-	RoundTrip(ctx context.Context, query []byte) (reply []byte, err error)
-}
+// RoundTripper is the old name for model.DNSRoundTripper.
+type RoundTripper model.DNSRoundTripper

--- a/internal/dnsconf/dnsconf.go
+++ b/internal/dnsconf/dnsconf.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ooni/netx/dnsx"
 	"github.com/ooni/netx/internal/connx"
 	"github.com/ooni/netx/internal/dialerapi"
 	"github.com/ooni/netx/internal/dnstransport/dnsoverhttps"
@@ -83,7 +82,7 @@ func NewResolver(
 	} else {
 		// FALLTHROUGH
 	}
-	var transport dnsx.RoundTripper
+	var transport model.DNSRoundTripper
 	if network == "doh" {
 		transport = dnsoverhttps.NewTransport(
 			newHTTPClientForDoH(dialer.Beginning, dialer.Handler), address,

--- a/internal/dnstransport/dnsoverhttps/dnsoverhttps.go
+++ b/internal/dnstransport/dnsoverhttps/dnsoverhttps.go
@@ -2,14 +2,14 @@
 package dnsoverhttps
 
 import (
-	"context"
 	"bytes"
+	"context"
 	"errors"
 	"io/ioutil"
 	"net/http"
 )
 
-// Transport is a DNS over HTTPS dnsx.RoundTripper.
+// Transport is a DNS over HTTPS model.DNSRoundTripper.
 //
 // As a known bug, this implementation does not cache the domain
 // name in the URL for reuse, but this should be easy to fix.

--- a/internal/dnstransport/dnsovertcp/dnsovertcp.go
+++ b/internal/dnstransport/dnsovertcp/dnsovertcp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/m-lab/go/rtx"
 )
 
-// Transport is a DNS over TCP/TLS dnsx.RoundTripper.
+// Transport is a DNS over TCP/TLS model.DNSRoundTripper.
 //
 // As a known bug, this implementation always creates a new connection
 // for each incoming query, thus increasing the response delay.

--- a/internal/dnstransport/dnsoverudp/dnsoverudp.go
+++ b/internal/dnstransport/dnsoverudp/dnsoverudp.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// Transport is a DNS over UDP dnsx.RoundTripper.
+// Transport is a DNS over UDP model.DNSRoundTripper.
 type Transport struct {
 	dial    func(network, address string) (net.Conn, error)
 	address string

--- a/internal/godns/godns.go
+++ b/internal/godns/godns.go
@@ -34,16 +34,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ooni/netx/dnsx"
 	"github.com/ooni/netx/internal/connx"
 	"github.com/ooni/netx/internal/dialerapi"
 	"github.com/ooni/netx/model"
 )
 
-// NewClient returns a dnsx.Client implementation that is using
+// NewClient returns a model.DNSResolver implementation that is using
 // the specified transport to resolve domain names.
 func NewClient(
-	beginning time.Time, handler model.Handler, transport dnsx.RoundTripper,
+	beginning time.Time, handler model.Handler, transport model.DNSRoundTripper,
 ) *net.Resolver {
 	return &net.Resolver{
 		PreferGo: true,
@@ -63,7 +62,7 @@ type pseudoConn struct {
 	id    int64
 	mutex sync.Mutex
 	rd    time.Time
-	t     dnsx.RoundTripper
+	t     model.DNSRoundTripper
 	wd    time.Time
 }
 
@@ -71,7 +70,7 @@ type pseudoConn struct {
 // specified transport. This allows a DNS client to write a query
 // to the conn to send it, and to read to receive the reply.
 func NewPseudoConn(
-	beginning time.Time, handler model.Handler, transport dnsx.RoundTripper,
+	beginning time.Time, handler model.Handler, transport model.DNSRoundTripper,
 ) net.Conn {
 	connid := dialerapi.NextConnID()
 	conn := net.Conn(&connx.DNSMeasuringConn{

--- a/internal/oodns/oodns.go
+++ b/internal/oodns/oodns.go
@@ -2,7 +2,7 @@
 //
 // This is currently experimental code that is not wired into the
 // rest of the code. We want to understand if we can always use the
-// github.com/miekg/dns client to implement dnsx.Client.
+// github.com/miekg/dns client to implement model.DNSResolver.
 //
 // If that is possible, then maybe we can fully replace the current
 // situation in which we monkey patch Go's +netgo DNS client.
@@ -14,7 +14,6 @@ import (
 	"net"
 
 	"github.com/miekg/dns"
-	"github.com/ooni/netx/dnsx"
 	"github.com/ooni/netx/model"
 )
 
@@ -23,11 +22,11 @@ import (
 // for DNS supported by this library, however.
 type Client struct {
 	handler   model.Handler
-	transport dnsx.RoundTripper
+	transport model.DNSRoundTripper
 }
 
 // NewClient creates a new OONI DNS client instance.
-func NewClient(handler model.Handler, t dnsx.RoundTripper) *Client {
+func NewClient(handler model.Handler, t model.DNSRoundTripper) *Client {
 	return &Client{
 		handler:   handler,
 		transport: t,
@@ -124,7 +123,7 @@ func (c *Client) roundTrip(ctx context.Context, query *dns.Msg) (reply *dns.Msg,
 		ctx, query, func(msg *dns.Msg) ([]byte, error) {
 			return msg.Pack()
 		},
-		func(t dnsx.RoundTripper, query []byte) (reply []byte, err error) {
+		func(t model.DNSRoundTripper, query []byte) (reply []byte, err error) {
 			// Pass ctx to round tripper for cancellation as well
 			// as to propagate context information
 			return t.RoundTrip(ctx, query)
@@ -141,7 +140,7 @@ func (c *Client) RoundTripEx(
 	ctx context.Context,
 	query *dns.Msg,
 	pack func(msg *dns.Msg) ([]byte, error),
-	roundTrip func(t dnsx.RoundTripper, query []byte) (reply []byte, err error),
+	roundTrip func(t model.DNSRoundTripper, query []byte) (reply []byte, err error),
 	unpack func(msg *dns.Msg, data []byte) (err error),
 ) (reply *dns.Msg, err error) {
 	// TODO(ooni): we are ignoring the context here

--- a/internal/oodns/oodns_test.go
+++ b/internal/oodns/oodns_test.go
@@ -8,13 +8,13 @@ import (
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/ooni/netx/dnsx"
 	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/internal/dnstransport/dnsovertcp"
 	"github.com/ooni/netx/internal/oodns"
+	"github.com/ooni/netx/model"
 )
 
-func newtransport() dnsx.RoundTripper {
+func newtransport() model.DNSRoundTripper {
 	return dnsovertcp.NewTransport(
 		func(network, address string) (net.Conn, error) {
 			return tls.Dial(network, address, nil)
@@ -110,7 +110,7 @@ func TestRoundTripExPackFailure(t *testing.T) {
 		func(msg *dns.Msg) ([]byte, error) {
 			return nil, errors.New("mocked error")
 		},
-		func(t dnsx.RoundTripper, query []byte) (reply []byte, err error) {
+		func(t model.DNSRoundTripper, query []byte) (reply []byte, err error) {
 			return nil, nil
 		},
 		func(msg *dns.Msg, data []byte) (err error) {
@@ -131,7 +131,7 @@ func TestRoundTripExRoundTripFailure(t *testing.T) {
 		func(msg *dns.Msg) ([]byte, error) {
 			return nil, nil
 		},
-		func(t dnsx.RoundTripper, query []byte) (reply []byte, err error) {
+		func(t model.DNSRoundTripper, query []byte) (reply []byte, err error) {
 			return nil, errors.New("mocked error")
 		},
 		func(msg *dns.Msg, data []byte) (err error) {
@@ -152,7 +152,7 @@ func TestRoundTripExUnpackFailure(t *testing.T) {
 		func(msg *dns.Msg) ([]byte, error) {
 			return nil, nil
 		},
-		func(t dnsx.RoundTripper, query []byte) (reply []byte, err error) {
+		func(t model.DNSRoundTripper, query []byte) (reply []byte, err error) {
 			return nil, nil
 		},
 		func(msg *dns.Msg, data []byte) (err error) {

--- a/model/model.go
+++ b/model/model.go
@@ -19,6 +19,8 @@
 package model
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"time"
 )
@@ -215,4 +217,29 @@ type Handler interface {
 	// or Client is returned. OnMeasurement may be called by background
 	// goroutines and OnMeasurement calls may happen concurrently.
 	OnMeasurement(Measurement)
+}
+
+// DNSResolver is a DNS resolver. The *net.Resolver used by Go implements
+// this interface, but other implementations are possible.
+type DNSResolver interface {
+	// LookupAddr performs a reverse lookup of an address.
+	LookupAddr(ctx context.Context, addr string) (names []string, err error)
+
+	// LookupCNAME returns the canonical name of a given host.
+	LookupCNAME(ctx context.Context, host string) (cname string, err error)
+
+	// LookupHost resolves a hostname to a list of IP addresses.
+	LookupHost(ctx context.Context, hostname string) (addrs []string, err error)
+
+	// LookupMX resolves the DNS MX records for a given domain name.
+	LookupMX(ctx context.Context, name string) ([]*net.MX, error)
+
+	// LookupNS resolves the DNS NS records for a given domain name.
+	LookupNS(ctx context.Context, name string) ([]*net.NS, error)
+}
+
+// DNSRoundTripper represents an abstract DNS transport.
+type DNSRoundTripper interface {
+	// RoundTrip sends a DNS query and receives the reply.
+	RoundTrip(ctx context.Context, query []byte) (reply []byte, err error)
 }

--- a/netx.go
+++ b/netx.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/ooni/netx/dnsx"
 	"github.com/ooni/netx/internal/dialerapi"
 	"github.com/ooni/netx/internal/dnsconf"
 	"github.com/ooni/netx/model"
@@ -103,7 +102,7 @@ func (d *Dialer) DialTLS(network, address string) (conn net.Conn, err error) {
 // The Resolver returned by NewResolver shares the same limitation of
 // ConfigureDNS. Under Windows the C library resolver is always used and
 // therefore it is not possible for us to see DNS events.
-func (d *Dialer) NewResolver(network, address string) (dnsx.Client, error) {
+func (d *Dialer) NewResolver(network, address string) (model.DNSResolver, error) {
 	return dnsconf.NewResolver(d.dialer, network, address)
 }
 


### PR DESCRIPTION
Keep dnsx because it's the API. Yet, move to save import headaches
and just have aliases in dsnx.