### PR TITLE
dnsovertcp: don't expose internals

### DIFF
--- a/internal/dnstransport/dnsovertcp/dnsovertcp.go
+++ b/internal/dnstransport/dnsovertcp/dnsovertcp.go
@@ -39,11 +39,10 @@ func (t *Transport) RoundTrip(ctx context.Context, query []byte) ([]byte, error)
 		return nil, err
 	}
 	defer conn.Close()
-	return t.RoundTripWithConn(conn, query)
+	return t.doWithConn(conn, query)
 }
 
-// RoundTripWithConn performs the DNS round trip with a connection.
-func (t *Transport) RoundTripWithConn(conn net.Conn, query []byte) (reply []byte, err error) {
+func (t *Transport) doWithConn(conn net.Conn, query []byte) (reply []byte, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			reply = nil // we already got the error just clear the reply

--- a/internal/dnstransport/dnsovertcp/dnsovertcp_test.go
+++ b/internal/dnstransport/dnsovertcp/dnsovertcp_test.go
@@ -61,7 +61,7 @@ func TestUnitRoundTripWithConnFailure(t *testing.T) {
 		return &fakeconn{}, nil
 	}, "8.8.8.8:53")
 	query := make([]byte, 1<<10)
-	reply, err := transport.RoundTripWithConn(&fakeconn{}, query)
+	reply, err := transport.doWithConn(&fakeconn{}, query)
 	if err == nil {
 		t.Fatal("expected an error here")
 	}


### PR DESCRIPTION
(More yak shaving.)