### PR TITLE
Use ConnID that we can generate from HTTP

### DIFF
--- a/internal/connid/connid.go
+++ b/internal/connid/connid.go
@@ -1,0 +1,31 @@
+// Package connid contains code to generate the connectionID
+package connid
+
+import (
+	"net"
+	"strconv"
+	"strings"
+)
+
+// Compute computes the connectionID from the local socket address. The zero
+// value is conventionally returned to mean "unknown".
+func Compute(network, address string) int64 {
+	_, portstring, err := net.SplitHostPort(address)
+	if err != nil {
+		return 0
+	}
+	portnum, err := strconv.Atoi(portstring)
+	if err != nil {
+		return 0
+	}
+	if portnum < 0 || portnum > 65535 {
+		return 0
+	}
+	result := int64(portnum)
+	if strings.Contains(network, "udp") {
+		result *= -1
+	} else if !strings.Contains(network, "tcp") {
+		result = 0
+	}
+	return result
+}

--- a/internal/connid/connid_test.go
+++ b/internal/connid/connid_test.go
@@ -1,0 +1,80 @@
+package connid
+
+import "testing"
+
+func TestIntegrationTCP(t *testing.T) {
+	num := Compute("tcp", "1.2.3.4:6789")
+	if num != 6789 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationTCP4(t *testing.T) {
+	num := Compute("tcp4", "130.192.91.211:34566")
+	if num != 34566 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationTCP6(t *testing.T) {
+	num := Compute("tcp4", "[::1]:4444")
+	if num != 4444 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationUDP(t *testing.T) {
+	num := Compute("udp", "1.2.3.4:6789")
+	if num != -6789 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationUDP4(t *testing.T) {
+	num := Compute("udp4", "130.192.91.211:34566")
+	if num != -34566 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationUDP6(t *testing.T) {
+	num := Compute("udp6", "[::1]:4444")
+	if num != -4444 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationInvalidAddress(t *testing.T) {
+	num := Compute("udp6", "[::1]")
+	if num != 0 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationInvalidPort(t *testing.T) {
+	num := Compute("udp6", "[::1]:antani")
+	if num != 0 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationNegativePort(t *testing.T) {
+	num := Compute("udp6", "[::1]:-1")
+	if num != 0 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationLargePort(t *testing.T) {
+	num := Compute("udp6", "[::1]:65536")
+	if num != 0 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestIntegrationInvalidNetwork(t *testing.T) {
+	num := Compute("unix", "[::1]:65531")
+	if num != 0 {
+		t.Fatal("unexpected result")
+	}
+}

--- a/internal/dialer/dialerbase/dialerbase_test.go
+++ b/internal/dialer/dialerbase/dialerbase_test.go
@@ -38,6 +38,6 @@ func TestIntegrationErrorNoConnect(t *testing.T) {
 // see whether we implement the interface
 func newdialer() model.Dialer {
 	return New(
-		time.Now(), handlers.NoHandler, new(net.Dialer), 17, 17,
+		time.Now(), handlers.NoHandler, new(net.Dialer), 17,
 	)
 }

--- a/internal/dialer/dnsdialer/dnsdialer.go
+++ b/internal/dialer/dnsdialer/dnsdialer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ooni/netx/model"
 )
 
-var nextDialID, nextConnID int64
+var nextDialID int64
 
 // Dialer defines the dialer API. We implement the most basic form
 // of DNS, but more advanced resolutions are possible.
@@ -51,10 +51,9 @@ func (d *Dialer) DialContext(
 		return nil, err
 	}
 	dialID := atomic.AddInt64(&nextDialID, 1)
-	connID := atomic.AddInt64(&nextConnID, 1)
 	if net.ParseIP(onlyhost) != nil {
 		dialer := dialerbase.New(
-			d.beginning, d.handler, d.dialer, dialID, connID,
+			d.beginning, d.handler, d.dialer, dialID,
 		)
 		conn, err = dialer.DialContext(ctx, network, address)
 		return
@@ -78,14 +77,13 @@ func (d *Dialer) DialContext(
 	}
 	for _, addr := range addrs {
 		dialer := dialerbase.New(
-			d.beginning, d.handler, d.dialer, dialID, connID,
+			d.beginning, d.handler, d.dialer, dialID,
 		)
 		target := net.JoinHostPort(addr, onlyport)
 		conn, err = dialer.DialContext(ctx, network, target)
 		if err == nil {
 			return
 		}
-		connID = atomic.AddInt64(&nextConnID, 1)
 	}
 	err = &net.OpError{
 		Op:  "dial",

--- a/internal/dialer/tlsdialer/tlsdialer_test.go
+++ b/internal/dialer/tlsdialer/tlsdialer_test.go
@@ -27,7 +27,7 @@ func TestIntegrationSuccess(t *testing.T) {
 func TestIntegrationSuccessWithMeasuringConn(t *testing.T) {
 	dialer := newdialer()
 	dialer.(*TLSDialer).dialer = dialerbase.New(
-		time.Now(), handlers.NoHandler, new(net.Dialer), 17, 17,
+		time.Now(), handlers.NoHandler, new(net.Dialer), 17,
 	)
 	conn, err := dialer.DialTLS("tcp", "www.google.com:443")
 	if err != nil {

--- a/internal/httptransport/tracetripper/tracetripper.go
+++ b/internal/httptransport/tracetripper/tracetripper.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ooni/netx/internal/connid"
 	"github.com/ooni/netx/internal/httptransport/transactioner"
 	"github.com/ooni/netx/model"
 )
@@ -42,7 +43,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		GotConn: func(info httptrace.GotConnInfo) {
 			t.handler.OnMeasurement(model.Measurement{
 				HTTPConnectionReady: &model.HTTPConnectionReadyEvent{
-					LocalAddress:  info.Conn.LocalAddr().String(),
+					ConnID: connid.Compute(
+						info.Conn.LocalAddr().Network(),
+						info.Conn.LocalAddr().String(),
+					),
 					Network:       info.Conn.LocalAddr().Network(),
 					RemoteAddress: info.Conn.RemoteAddr().String(),
 					Time:          time.Now().Sub(t.beginning),

--- a/model/model.go
+++ b/model/model.go
@@ -1,10 +1,9 @@
 // Package model contains the data model. Network events are tagged
 // using a unique int64 ConnID. HTTP events also have a unique int64
-// ID, TransactionID. These IDs are never reused.
-//
-// To join network events and HTTP events, use the LocalAddress and
-// RemoteAddress that are included both in the ConnectEvent and in
-// the HTTPConnectionReadyEvent.
+// ID, TransactionID. Dial events also have their own DialID. A
+// zero ID value always means unknown. We never reuse the DialID
+// and the TransactionID. For technical reasons, we need to use a
+// ConnID that depends on the five tuple, so they're reused.
 //
 // All events also have a Time. This is always the time in which
 // an event has been emitted. We use a monotonic clock. Hence, the
@@ -39,7 +38,6 @@ type ConnectEvent struct {
 	DialID        int64
 	Duration      time.Duration
 	Error         error
-	LocalAddress  string
 	Network       string
 	RemoteAddress string
 	Time          time.Duration
@@ -66,7 +64,7 @@ type DNSReplyEvent struct {
 
 // HTTPConnectionReadyEvent is emitted when a connection is ready for HTTP.
 type HTTPConnectionReadyEvent struct {
-	LocalAddress  string
+	ConnID        int64
 	Network       string
 	RemoteAddress string
 	Time          time.Duration


### PR DESCRIPTION
We are using the local port and the protocol. This makes it
possible to join HTTP and network level measurements.