### PR TITLE
[DATA CHANGE] Clearly identify the round trip

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 | Author       | Simone Basso |
 |--------------|--------------|
-| Last-Updated | 2019-10-24   |
+| Last-Updated | 2019-10-26   |
 | Status       | approved     |
 
 ## Introduction
@@ -165,22 +165,10 @@ as follows:
 
 ```Go
 type Measurement struct {
-    Close                   *CloseEvent
-    Connect                 *ConnectEvent
-    DNSQuery                *DNSQueryEvent
-    DNSReply                *DNSReplyEvent
-    HTTPConnectionReady     *HTTPConnectionReadyEvent
-    HTTPRequestStart        *HTTPRequestStartEvent
-    HTTPRequestHeadersDone  *HTTPRequestHeadersDoneEvent
-    HTTPRequestDone         *HTTPRequestDoneEvent
-    HTTPResponseStart       *HTTPResponseStartEvent
-    HTTPResponseHeadersDone *HTTPResponseHeadersDoneEvent
-    HTTPResponseBodyPart    *HTTPResponseBodyPartEvent
-    HTTPResponseDone        *HTTPResponseDoneEvent
-    Read                    *ReadEvent
-    Resolve                 *ResolveEvent
-    TLSHandshake            *TLSHandshakeEvent
-    Write                   *WriteEvent
+    Read  *ReadEvent
+    Write *WriteEvent
+
+    // more similar events ...
 }
 ```
 
@@ -189,105 +177,8 @@ that we support. The events processing code will
 check what pointer or pointers are not `nil` to
 known which event or events have occurred.
 
-The following network-level events will be defined:
-
-1. `CloseEvent`, indicating when a socket is closed
-2. `ConnectEvent`, indicating the result of connecting
-3. `ReadEvent`, indicating when a `read` completes
-4. `ResolveEvent`, indicating when a name resolution completes
-5. `WriteEvent`, indicating when a `write` completes
-
-The following DNS-level events will be defined:
-
-1. `DNSQueryEvent`, containing the query data
-2. `DNSReplyEvent`, containing the reply data
-
-The following HTTP-level events will be defined:
-
-1. `HTTPConnectionReadyEvent`, indicating when the connection
-is ready to be used by HTTP code
-
-2. `HTTPRequestStartEvent`, indicating when we start sending the request
-
-3. `HTTPRequestHeadersDoneEvent`, indicating when we have sent the
-request headers, and containing the sent headers
-
-4. `HTTPRequestDoneEvent`, indicating when the whole request has been sent
-
-5. `HTTPResponseStartEvent`, indicacting when we receive the first
-byte of the HTTP response
-
-6. `HTTPResponseHeadersDoneEvent`, indicating when we have received the
-response headers, and containing headers and status code
-
-7. `HTTPResponseBodyPartEvent`, indicating when we have received a
-part of the response body, or an error reading it
-
-8. `HTTPResponseDoneEvent`, indicating when we have received the
-response body
-
-Every event will include at the minimum this field:
-
-```Go
-    Time     time.Duration
-```
-
-This will be the time when the event occurred, relative to
-a configured "zero" time. If an event pertains to a blocking
-operation (i.e. `Read`), it will also contain this field:
-
-```Go
-    Duration time.Duration
-```
-
-This will be the amount time we have been waiting for
-the event to occur. That is, in the case of `Read` the
-amount of time we've been blocking waiting for the `Read`
-operation to return a value or an error.
-
-Every operation that can fail will have a field
-
-```Go
-    Error    error
-```
-
-This will indicate the error that occurred.
-
-Measurement events will also contain contextual information
-that is meaningful to the event itself. Since this is likely
-to change as we improve our understanding of what could
-be measured, as stated above, please see the current documentation
-for more information on the structure of each event.
-
-Every dialing operation will be identified by
-
-```Go
-    DialID   int64
-```
-
-Every established network connection will be additionally identified by
-
-```Go
-    ConnID   int64
-```
-
-Where `ConnID` is the identifier of the connection and is
-generated from the five tuple.
-
-Likewise, HTTP events will have their
-
-```Go
-    TransactionID int64
-```
-
-which will uniquely identify the round trip within a specific
-set of measurements.
-
-Mapping HTTP events to network events is easy because the
-`HTTPConnectionReadyEvent` contains the `ConnID`.
-
-Mapping dial events to connections is easy because the
-`ConnectEvent` includes also the `DialID`.
+For every detail regarding the structure of the
+events, we defer to the current docs.
 
 ### The github.com/ooni/netx/httpx package
 

--- a/internal/httptransport/bodyreader/bodyreader.go
+++ b/internal/httptransport/bodyreader/bodyreader.go
@@ -38,14 +38,6 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	if err != nil {
 		return
 	}
-	t.handler.OnMeasurement(model.Measurement{
-		HTTPResponseHeadersDone: &model.HTTPResponseHeadersDoneEvent{
-			Headers:       resp.Header,
-			StatusCode:    int64(resp.StatusCode),
-			Time:          time.Now().Sub(t.beginning),
-			TransactionID: tid,
-		},
-	})
 	// "The http Client and Transport guarantee that Body is always
 	//  non-nil, even on responses without a body or responses with
 	//  a zero-length body." (from the docs)

--- a/model/model.go
+++ b/model/model.go
@@ -71,8 +71,8 @@ type HTTPConnectionReadyEvent struct {
 	TransactionID int64
 }
 
-// HTTPRequestStartEvent is emitted when we start sending the request.
-type HTTPRequestStartEvent struct {
+// HTTPRoundTripStartEvent is emitted when we start the round trip.
+type HTTPRoundTripStartEvent struct {
 	Time          time.Duration
 	TransactionID int64
 }
@@ -98,8 +98,10 @@ type HTTPResponseStartEvent struct {
 	TransactionID int64
 }
 
-// HTTPResponseHeadersDoneEvent is emitted after we have received the headers.
-type HTTPResponseHeadersDoneEvent struct {
+// HTTPRoundTripDoneEvent is emitted at the end of the round trip. Either
+// we have an error, or a valid HTTP response.
+type HTTPRoundTripDoneEvent struct {
+	Error         error
 	Headers       http.Header
 	StatusCode    int64
 	Time          time.Duration
@@ -191,22 +193,25 @@ type WriteEvent struct {
 // time a Measurement will only contain a single event. When a Measurement
 // contains an event, the corresponding pointer is non nil.
 type Measurement struct {
-	Close                   *CloseEvent                   `json:",omitempty"`
-	Connect                 *ConnectEvent                 `json:",omitempty"`
-	DNSQuery                *DNSQueryEvent                `json:",omitempty"`
-	DNSReply                *DNSReplyEvent                `json:",omitempty"`
-	HTTPConnectionReady     *HTTPConnectionReadyEvent     `json:",omitempty"`
-	HTTPRequestStart        *HTTPRequestStartEvent        `json:",omitempty"`
-	HTTPRequestHeadersDone  *HTTPRequestHeadersDoneEvent  `json:",omitempty"`
-	HTTPRequestDone         *HTTPRequestDoneEvent         `json:",omitempty"`
-	HTTPResponseStart       *HTTPResponseStartEvent       `json:",omitempty"`
-	HTTPResponseHeadersDone *HTTPResponseHeadersDoneEvent `json:",omitempty"`
-	HTTPResponseBodyPart    *HTTPResponseBodyPartEvent    `json:",omitempty"`
-	HTTPResponseDone        *HTTPResponseDoneEvent        `json:",omitempty"`
-	Read                    *ReadEvent                    `json:",omitempty"`
-	Resolve                 *ResolveEvent                 `json:",omitempty"`
-	TLSHandshake            *TLSHandshakeEvent            `json:",omitempty"`
-	Write                   *WriteEvent                   `json:",omitempty"`
+	Close    *CloseEvent    `json:",omitempty"`
+	Connect  *ConnectEvent  `json:",omitempty"`
+	DNSQuery *DNSQueryEvent `json:",omitempty"`
+	DNSReply *DNSReplyEvent `json:",omitempty"`
+
+	// HTTP roundtrip events
+	HTTPRoundTripStart     *HTTPRoundTripStartEvent     `json:",omitempty"`
+	HTTPConnectionReady    *HTTPConnectionReadyEvent    `json:",omitempty"`
+	HTTPRequestHeadersDone *HTTPRequestHeadersDoneEvent `json:",omitempty"`
+	HTTPRequestDone        *HTTPRequestDoneEvent        `json:",omitempty"`
+	HTTPResponseStart      *HTTPResponseStartEvent      `json:",omitempty"`
+	HTTPRoundTripDone      *HTTPRoundTripDoneEvent      `json:",omitempty"`
+
+	HTTPResponseBodyPart *HTTPResponseBodyPartEvent `json:",omitempty"`
+	HTTPResponseDone     *HTTPResponseDoneEvent     `json:",omitempty"`
+	Read                 *ReadEvent                 `json:",omitempty"`
+	Resolve              *ResolveEvent              `json:",omitempty"`
+	TLSHandshake         *TLSHandshakeEvent         `json:",omitempty"`
+	Write                *WriteEvent                `json:",omitempty"`
 }
 
 // Handler handles measurement events.


### PR DESCRIPTION
The round trip is what happens since we start thinking about
sending a request until when we receive response.

This is a clearly defined operation with a well defined result
indicating error or HTTP response headers.

As such, emit its events in the proper model, and make sure
that we also emit the error that occurred (if any).

This change simplifies data analysis.

While there, stop duplicating docs in the design document, since
we are going to change events more times in the future.