### PR TITLE
internal: make measurements context rooted

### DIFF
--- a/internal/dialer/dialer.go
+++ b/internal/dialer/dialer.go
@@ -4,7 +4,6 @@ package dialer
 
 import (
 	"crypto/tls"
-	"time"
 
 	"github.com/ooni/netx/internal/dialer/dnsdialer"
 	"github.com/ooni/netx/internal/dialer/tlsdialer"
@@ -12,25 +11,11 @@ import (
 )
 
 // New creates a new model.Dialer
-func New(
-	beginning time.Time,
-	handler model.Handler,
-	resolver model.DNSResolver,
-	dialer model.Dialer,
-) *dnsdialer.Dialer {
-	return dnsdialer.New(
-		beginning, handler, resolver, dialer,
-	)
+func New(resolver model.DNSResolver, dialer model.Dialer) *dnsdialer.Dialer {
+	return dnsdialer.New(resolver, dialer)
 }
 
 // NewTLS creates a new model.TLSDialer
-func NewTLS(
-	beginning time.Time,
-	handler model.Handler,
-	dialer model.Dialer,
-	config *tls.Config,
-) *tlsdialer.TLSDialer {
-	return tlsdialer.New(
-		beginning, handler, dialer, config,
-	)
+func NewTLS(dialer model.Dialer, config *tls.Config) *tlsdialer.TLSDialer {
+	return tlsdialer.New(dialer, config)
 }

--- a/internal/dialer/dialer_test.go
+++ b/internal/dialer/dialer_test.go
@@ -4,19 +4,12 @@ import (
 	"crypto/tls"
 	"net"
 	"testing"
-	"time"
 
-	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/model"
 )
 
 func TestIntegrationNew(t *testing.T) {
-	var dialer model.Dialer = New(
-		time.Now(),
-		handlers.NoHandler,
-		new(net.Resolver),
-		new(net.Dialer),
-	)
+	var dialer model.Dialer = New(new(net.Resolver), new(net.Dialer))
 	conn, err := dialer.Dial("tcp", "www.kernel.org:80")
 	if err != nil {
 		t.Fatal(err)
@@ -28,12 +21,7 @@ func TestIntegrationNew(t *testing.T) {
 }
 
 func TestIntegrationNewTLS(t *testing.T) {
-	var dialer model.TLSDialer = NewTLS(
-		time.Now(),
-		handlers.NoHandler,
-		new(net.Dialer),
-		new(tls.Config),
-	)
+	var dialer model.TLSDialer = NewTLS(new(net.Dialer), new(tls.Config))
 	conn, err := dialer.DialTLS("tcp", "www.kernel.org:443")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/dialer/dnsdialer/dnsdialer.go
+++ b/internal/dialer/dnsdialer/dnsdialer.go
@@ -17,22 +17,15 @@ var nextDialID int64
 // Dialer defines the dialer API. We implement the most basic form
 // of DNS, but more advanced resolutions are possible.
 type Dialer struct {
-	beginning time.Time
-	dialer    model.Dialer
-	handler   model.Handler
-	resolver  model.DNSResolver
+	dialer   model.Dialer
+	resolver model.DNSResolver
 }
 
 // New creates a new Dialer.
-func New(
-	beginning time.Time, handler model.Handler,
-	resolver model.DNSResolver, dialer model.Dialer,
-) (d *Dialer) {
+func New(resolver model.DNSResolver, dialer model.Dialer) (d *Dialer) {
 	return &Dialer{
-		beginning: beginning,
-		dialer:    dialer,
-		handler:   handler,
-		resolver:  resolver,
+		dialer:   dialer,
+		resolver: resolver,
 	}
 }
 
@@ -46,6 +39,7 @@ func (d *Dialer) Dial(network, address string) (net.Conn, error) {
 func (d *Dialer) DialContext(
 	ctx context.Context, network, address string,
 ) (conn net.Conn, err error) {
+	root := model.ContextMeasurementRootOrDefault(ctx)
 	onlyhost, onlyport, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err
@@ -53,7 +47,7 @@ func (d *Dialer) DialContext(
 	dialID := atomic.AddInt64(&nextDialID, 1)
 	if net.ParseIP(onlyhost) != nil {
 		dialer := dialerbase.New(
-			d.beginning, d.handler, d.dialer, dialID,
+			root.Beginning, root.Handler, d.dialer, dialID,
 		)
 		conn, err = dialer.DialContext(ctx, network, address)
 		return
@@ -62,14 +56,14 @@ func (d *Dialer) DialContext(
 	var addrs []string
 	addrs, err = d.resolver.LookupHost(ctx, onlyhost)
 	stop := time.Now()
-	d.handler.OnMeasurement(model.Measurement{
+	root.Handler.OnMeasurement(model.Measurement{
 		Resolve: &model.ResolveEvent{
 			Addresses: addrs,
 			DialID:    dialID,
 			Duration:  stop.Sub(start),
 			Error:     err,
 			Hostname:  onlyhost,
-			Time:      stop.Sub(d.beginning),
+			Time:      stop.Sub(root.Beginning),
 		},
 	})
 	if err != nil {
@@ -77,7 +71,7 @@ func (d *Dialer) DialContext(
 	}
 	for _, addr := range addrs {
 		dialer := dialerbase.New(
-			d.beginning, d.handler, d.dialer, dialID,
+			root.Beginning, root.Handler, d.dialer, dialID,
 		)
 		target := net.JoinHostPort(addr, onlyport)
 		conn, err = dialer.DialContext(ctx, network, target)

--- a/internal/dialer/dnsdialer/dnsdialer_test.go
+++ b/internal/dialer/dnsdialer/dnsdialer_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/model"
 )
 
@@ -66,10 +65,5 @@ func TestIntegrationDialTCPFailure(t *testing.T) {
 }
 
 func newdialer() model.Dialer {
-	return New(
-		time.Now(),
-		handlers.NoHandler,
-		new(net.Resolver),
-		new(net.Dialer),
-	)
+	return New(new(net.Resolver), new(net.Dialer))
 }

--- a/internal/dialer/tlsdialer/tlsdialer_test.go
+++ b/internal/dialer/tlsdialer/tlsdialer_test.go
@@ -89,10 +89,5 @@ func TestIntegrationFailureSetDeadline(t *testing.T) {
 }
 
 func newdialer() model.TLSDialer {
-	return New(
-		time.Now(),
-		handlers.NoHandler,
-		new(net.Dialer),
-		new(tls.Config),
-	)
+	return New(new(net.Dialer), new(tls.Config))
 }

--- a/internal/httptransport/bodyreader/bodyreader.go
+++ b/internal/httptransport/bodyreader/bodyreader.go
@@ -13,27 +13,17 @@ import (
 // Transport performs single HTTP transactions and emits
 // measurement events as they happen.
 type Transport struct {
-	beginning    time.Time
-	handler      model.Handler
 	roundTripper http.RoundTripper
 }
 
 // New creates a new Transport.
-func New(
-	beginning time.Time, handler model.Handler,
-	roundTripper http.RoundTripper,
-) *Transport {
-	return &Transport{
-		beginning:    beginning,
-		handler:      handler,
-		roundTripper: roundTripper,
-	}
+func New(roundTripper http.RoundTripper) *Transport {
+	return &Transport{roundTripper: roundTripper}
 }
 
 // RoundTrip executes a single HTTP transaction, returning
 // a Response for the provided Request.
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	tid := transactioner.ContextTransactionID(req.Context())
 	resp, err = t.roundTripper.RoundTrip(req)
 	if err != nil {
 		return
@@ -43,8 +33,8 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	//  a zero-length body." (from the docs)
 	resp.Body = &bodyWrapper{
 		ReadCloser: resp.Body,
-		t:          t,
-		tid:        tid,
+		root:       model.ContextMeasurementRootOrDefault(req.Context()),
+		tid:        transactioner.ContextTransactionID(req.Context()),
 	}
 	return
 }
@@ -62,15 +52,15 @@ func (t *Transport) CloseIdleConnections() {
 
 type bodyWrapper struct {
 	io.ReadCloser
-	t   *Transport
-	tid int64
+	root *model.MeasurementRoot
+	tid  int64
 }
 
 func (bw *bodyWrapper) Read(b []byte) (n int, err error) {
 	start := time.Now()
 	n, err = bw.ReadCloser.Read(b)
 	stop := time.Now()
-	bw.t.handler.OnMeasurement(model.Measurement{
+	bw.root.Handler.OnMeasurement(model.Measurement{
 		HTTPResponseBodyPart: &model.HTTPResponseBodyPartEvent{
 			// "Read reads up to len(p) bytes into p. It returns the number of
 			// bytes read (0 <= n <= len(p)) and any error encountered."
@@ -78,7 +68,7 @@ func (bw *bodyWrapper) Read(b []byte) (n int, err error) {
 			Duration:      stop.Sub(start),
 			Error:         err,
 			NumBytes:      int64(n),
-			Time:          stop.Sub(bw.t.beginning),
+			Time:          stop.Sub(bw.root.Beginning),
 			TransactionID: bw.tid,
 		},
 	})
@@ -87,9 +77,9 @@ func (bw *bodyWrapper) Read(b []byte) (n int, err error) {
 
 func (bw *bodyWrapper) Close() (err error) {
 	err = bw.ReadCloser.Close()
-	bw.t.handler.OnMeasurement(model.Measurement{
+	bw.root.Handler.OnMeasurement(model.Measurement{
 		HTTPResponseDone: &model.HTTPResponseDoneEvent{
-			Time:          time.Now().Sub(bw.t.beginning),
+			Time:          time.Now().Sub(bw.root.Beginning),
 			TransactionID: bw.tid,
 		},
 	})

--- a/internal/httptransport/bodyreader/bodyreader_test.go
+++ b/internal/httptransport/bodyreader/bodyreader_test.go
@@ -4,14 +4,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
-	"time"
-
-	"github.com/ooni/netx/handlers"
 )
 
 func TestIntegration(t *testing.T) {
 	client := &http.Client{
-		Transport: New(time.Now(), handlers.NoHandler, http.DefaultTransport),
+		Transport: New(http.DefaultTransport),
 	}
 	resp, err := client.Get("https://www.google.com")
 	if err != nil {
@@ -27,7 +24,7 @@ func TestIntegration(t *testing.T) {
 
 func TestIntegrationFailure(t *testing.T) {
 	client := &http.Client{
-		Transport: New(time.Now(), handlers.NoHandler, http.DefaultTransport),
+		Transport: New(http.DefaultTransport),
 	}
 	// This fails the request because we attempt to speak cleartext HTTP with
 	// a server that instead is expecting TLS.

--- a/internal/httptransport/httptransport.go
+++ b/internal/httptransport/httptransport.go
@@ -4,12 +4,10 @@ package httptransport
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/ooni/netx/internal/httptransport/bodyreader"
 	"github.com/ooni/netx/internal/httptransport/tracetripper"
 	"github.com/ooni/netx/internal/httptransport/transactioner"
-	"github.com/ooni/netx/model"
 )
 
 // Transport performs single HTTP transactions and emits
@@ -19,16 +17,11 @@ type Transport struct {
 }
 
 // New creates a new Transport.
-func New(
-	beginning time.Time, handler model.Handler,
-	roundTripper http.RoundTripper,
-) *Transport {
+func New(roundTripper http.RoundTripper) *Transport {
 	return &Transport{
 		roundTripper: transactioner.New(bodyreader.New(
-			beginning, handler, tracetripper.New(
-				beginning, handler, roundTripper,
-			),
-		))}
+			tracetripper.New(roundTripper))),
+	}
 }
 
 // RoundTrip executes a single HTTP transaction, returning

--- a/internal/httptransport/httptransport_test.go
+++ b/internal/httptransport/httptransport_test.go
@@ -4,14 +4,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
-	"time"
-
-	"github.com/ooni/netx/handlers"
 )
 
 func TestIntegration(t *testing.T) {
 	client := &http.Client{
-		Transport: New(time.Now(), handlers.NoHandler, http.DefaultTransport),
+		Transport: New(http.DefaultTransport),
 	}
 	resp, err := client.Get("https://www.google.com")
 	if err != nil {
@@ -27,7 +24,7 @@ func TestIntegration(t *testing.T) {
 
 func TestIntegrationFailure(t *testing.T) {
 	client := &http.Client{
-		Transport: New(time.Now(), handlers.NoHandler, http.DefaultTransport),
+		Transport: New(http.DefaultTransport),
 	}
 	// This fails the request because we attempt to speak cleartext HTTP with
 	// a server that instead is expecting TLS.

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -266,4 +267,48 @@ func TestIntegrationFailure(t *testing.T) {
 		t.Fatal("expected a nil response here")
 	}
 	client.CloseIdleConnections()
+}
+
+func TestLookupAddrWrapper(t *testing.T) {
+	resolver := newResolverWrapper(time.Now(), handlers.NoHandler, new(net.Resolver))
+	names, err := resolver.LookupAddr(context.Background(), "8.8.8.8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) < 1 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestLookupCNAMEWrapper(t *testing.T) {
+	resolver := newResolverWrapper(time.Now(), handlers.NoHandler, new(net.Resolver))
+	name, err := resolver.LookupCNAME(context.Background(), "www.google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name == "" {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestLookupMXWrapper(t *testing.T) {
+	resolver := newResolverWrapper(time.Now(), handlers.NoHandler, new(net.Resolver))
+	entries, err := resolver.LookupMX(context.Background(), "google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) < 1 {
+		t.Fatal("unexpected result")
+	}
+}
+
+func TestLookupNSWrapper(t *testing.T) {
+	resolver := newResolverWrapper(time.Now(), handlers.NoHandler, new(net.Resolver))
+	entries, err := resolver.LookupNS(context.Background(), "google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) < 1 {
+		t.Fatal("unexpected result")
+	}
 }

--- a/internal/resolver/ooniresolver/ooniresolver.go
+++ b/internal/resolver/ooniresolver/ooniresolver.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"time"
 
 	"github.com/miekg/dns"
 	"github.com/ooni/netx/model"
@@ -15,16 +14,12 @@ import (
 // manually create and submit queries. It can use all the transports
 // for DNS supported by this library, however.
 type Resolver struct {
-	handler   model.Handler
 	transport model.DNSRoundTripper
 }
 
 // New creates a new OONI Resolver instance.
-func New(beginning time.Time, handler model.Handler, t model.DNSRoundTripper) *Resolver {
-	return &Resolver{
-		handler:   handler,
-		transport: t,
-	}
+func New(t model.DNSRoundTripper) *Resolver {
+	return &Resolver{transport: t}
 }
 
 var errNotImpl = errors.New("Not implemented")

--- a/internal/resolver/ooniresolver/ooniresolver_test.go
+++ b/internal/resolver/ooniresolver/ooniresolver_test.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/miekg/dns"
-	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/internal/resolver/dnstransport/dnsovertcp"
 	"github.com/ooni/netx/model"
 )
@@ -18,9 +16,7 @@ func newtransport() model.DNSRoundTripper {
 }
 
 func TestLookupAddr(t *testing.T) {
-	client := New(
-		time.Now(), handlers.NoHandler, newtransport(),
-	)
+	client := New(newtransport())
 	addrs, err := client.LookupAddr(context.Background(), "130.192.91.211")
 	if err == nil {
 		t.Fatal("expected an error here")
@@ -31,9 +27,7 @@ func TestLookupAddr(t *testing.T) {
 }
 
 func TestLookupCNAME(t *testing.T) {
-	client := New(
-		time.Now(), handlers.NoHandler, newtransport(),
-	)
+	client := New(newtransport())
 	addrs, err := client.LookupCNAME(context.Background(), "www.ooni.io")
 	if err == nil {
 		t.Fatal("expected an error here")
@@ -44,9 +38,7 @@ func TestLookupCNAME(t *testing.T) {
 }
 
 func TestLookupHost(t *testing.T) {
-	client := New(
-		time.Now(), handlers.NoHandler, newtransport(),
-	)
+	client := New(newtransport())
 	addrs, err := client.LookupHost(context.Background(), "www.google.com")
 	if err != nil {
 		t.Fatal(err)
@@ -57,9 +49,7 @@ func TestLookupHost(t *testing.T) {
 }
 
 func TestLookupNonexistent(t *testing.T) {
-	client := New(
-		time.Now(), handlers.NoHandler, newtransport(),
-	)
+	client := New(newtransport())
 	addrs, err := client.LookupHost(context.Background(), "nonexistent.ooni.io")
 	if err == nil {
 		t.Fatal("expected an error here")
@@ -70,9 +60,7 @@ func TestLookupNonexistent(t *testing.T) {
 }
 
 func TestLookupMX(t *testing.T) {
-	client := New(
-		time.Now(), handlers.NoHandler, newtransport(),
-	)
+	client := New(newtransport())
 	addrs, err := client.LookupMX(context.Background(), "ooni.io")
 	if err == nil {
 		t.Fatal("expected an error here")
@@ -83,9 +71,7 @@ func TestLookupMX(t *testing.T) {
 }
 
 func TestLookupNS(t *testing.T) {
-	client := New(
-		time.Now(), handlers.NoHandler, newtransport(),
-	)
+	client := New(newtransport())
 	addrs, err := client.LookupNS(context.Background(), "ooni.io")
 	if err == nil {
 		t.Fatal("expected an error here")
@@ -96,9 +82,7 @@ func TestLookupNS(t *testing.T) {
 }
 
 func TestRoundTripExPackFailure(t *testing.T) {
-	client := New(
-		time.Now(), handlers.NoHandler, newtransport(),
-	)
+	client := New(newtransport())
 	_, err := client.mockableRoundTrip(
 		context.Background(), nil,
 		func(msg *dns.Msg) ([]byte, error) {
@@ -117,9 +101,7 @@ func TestRoundTripExPackFailure(t *testing.T) {
 }
 
 func TestRoundTripExRoundTripFailure(t *testing.T) {
-	client := New(
-		time.Now(), handlers.NoHandler, newtransport(),
-	)
+	client := New(newtransport())
 	_, err := client.mockableRoundTrip(
 		context.Background(), nil,
 		func(msg *dns.Msg) ([]byte, error) {
@@ -138,9 +120,7 @@ func TestRoundTripExRoundTripFailure(t *testing.T) {
 }
 
 func TestRoundTripExUnpackFailure(t *testing.T) {
-	client := New(
-		time.Now(), handlers.NoHandler, newtransport(),
-	)
+	client := New(newtransport())
 	_, err := client.mockableRoundTrip(
 		context.Background(), nil,
 		func(msg *dns.Msg) ([]byte, error) {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -3,7 +3,6 @@ package resolver
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/ooni/netx/internal/resolver/dnstransport/dnsoverhttps"
 	"github.com/ooni/netx/internal/resolver/dnstransport/dnsovertcp"
@@ -13,46 +12,23 @@ import (
 )
 
 // NewResolverUDP creates a new UDP resolver.
-func NewResolverUDP(
-	beginning time.Time, handler model.Handler,
-	dialer model.Dialer, address string,
-) *ooniresolver.Resolver {
-	return ooniresolver.New(
-		beginning, handler, dnsoverudp.NewTransport(dialer, address),
-	)
+func NewResolverUDP(dialer model.Dialer, address string) *ooniresolver.Resolver {
+	return ooniresolver.New(dnsoverudp.NewTransport(dialer, address))
 }
 
 // NewResolverTCP creates a new TCP resolver.
-func NewResolverTCP(
-	beginning time.Time, handler model.Handler,
-	dialer model.Dialer, address string,
-) *ooniresolver.Resolver {
-	return ooniresolver.New(
-		beginning, handler, dnsovertcp.NewTransport(dialer, address),
-	)
+func NewResolverTCP(dialer model.Dialer, address string) *ooniresolver.Resolver {
+	return ooniresolver.New(dnsovertcp.NewTransport(dialer, address))
 }
 
 // NewResolverTLS creates a new DoT resolver.
-func NewResolverTLS(
-	beginning time.Time, handler model.Handler,
-	dialer model.TLSDialer, address string,
-) *ooniresolver.Resolver {
-	return ooniresolver.New(
-		beginning, handler, dnsovertcp.NewTransport(
-			dnsovertcp.NewTLSDialerAdapter(dialer),
-			address,
-		),
+func NewResolverTLS(dialer model.TLSDialer, address string) *ooniresolver.Resolver {
+	return ooniresolver.New(dnsovertcp.NewTransport(
+		dnsovertcp.NewTLSDialerAdapter(dialer), address),
 	)
 }
 
 // NewResolverHTTPS creates a new DoH resolver.
-func NewResolverHTTPS(
-	beginning time.Time, handler model.Handler,
-	client *http.Client, address string,
-) *ooniresolver.Resolver {
-	return ooniresolver.New(
-		beginning, handler, dnsoverhttps.NewTransport(
-			client, address,
-		),
-	)
+func NewResolverHTTPS(client *http.Client, address string) *ooniresolver.Resolver {
+	return ooniresolver.New(dnsoverhttps.NewTransport(client, address))
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -6,9 +6,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
-	"time"
 
-	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/model"
 )
 
@@ -33,38 +31,37 @@ func testresolverquick(t *testing.T, resolver model.DNSResolver) {
 
 func TestIntegrationNewResolverUDPAddress(t *testing.T) {
 	testresolverquick(t, NewResolverUDP(
-		time.Now(), handlers.NoHandler, new(net.Dialer), "8.8.8.8:53"))
+		new(net.Dialer), "8.8.8.8:53"))
 }
 
 func TestIntegrationNewResolverUDPDomain(t *testing.T) {
 	testresolverquick(t, NewResolverUDP(
-		time.Now(), handlers.NoHandler, new(net.Dialer), "dns.google.com:53"))
+		new(net.Dialer), "dns.google.com:53"))
 }
 
 func TestIntegrationNewResolverTCPAddress(t *testing.T) {
 	testresolverquick(t, NewResolverTCP(
-		time.Now(), handlers.NoHandler, new(net.Dialer), "8.8.8.8:53"))
+		new(net.Dialer), "8.8.8.8:53"))
 }
 
 func TestIntegrationNewResolverTCPDomain(t *testing.T) {
 	testresolverquick(t, NewResolverTCP(
-		time.Now(), handlers.NoHandler, new(net.Dialer), "dns.google.com:53"))
+		new(net.Dialer), "dns.google.com:53"))
 }
 
 func TestIntegrationNewResolverDoTAddress(t *testing.T) {
 	testresolverquick(t, NewResolverTLS(
-		time.Now(), handlers.NoHandler, &tlsdialer{}, "9.9.9.9:853"))
+		&tlsdialer{}, "9.9.9.9:853"))
 }
 
 func TestIntegrationNewResolverDoTDomain(t *testing.T) {
 	testresolverquick(t, NewResolverTLS(
-		time.Now(), handlers.NoHandler, &tlsdialer{}, "dns.quad9.net:853"))
+		&tlsdialer{}, "dns.quad9.net:853"))
 }
 
 func TestIntegrationNewResolverDoH(t *testing.T) {
 	testresolverquick(t, NewResolverHTTPS(
-		time.Now(), handlers.NoHandler, http.DefaultClient,
-		"https://cloudflare-dns.com/dns-query"))
+		http.DefaultClient, "https://cloudflare-dns.com/dns-query"))
 }
 
 type tlsdialer struct{}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1,0 +1,56 @@
+package model
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+	"time"
+)
+
+func TestNewTLSConnectionState(t *testing.T) {
+	conn, err := tls.Dial("tcp", "www.google.com:443", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := NewTLSConnectionState(conn.ConnectionState())
+	if len(state.PeerCertificates) < 1 {
+		t.Fatal("too few certificates")
+	}
+	if state.Version < tls.VersionSSL30 || state.Version > 0x0304 /*tls.VersionTLS13*/ {
+		t.Fatal("unexpected TLS version")
+	}
+}
+
+func TestMeasurementRoot(t *testing.T) {
+	ctx := context.Background()
+	if ContextMeasurementRoot(ctx) != nil {
+		t.Fatal("unexpected value for ContextMeasurementRoot")
+	}
+	if ContextMeasurementRootOrDefault(ctx) == nil {
+		t.Fatal("unexpected value ContextMeasurementRootOrDefault")
+	}
+	handler := &dummyHandler{}
+	root := &MeasurementRoot{
+		Handler:   handler,
+		Beginning: time.Time{},
+	}
+	ctx = WithMeasurementRoot(ctx, root)
+	v := ContextMeasurementRoot(ctx)
+	if v != root {
+		t.Fatal("unexpected ContextMeasurementRoot value")
+	}
+	v = ContextMeasurementRootOrDefault(ctx)
+	if v != root {
+		t.Fatal("unexpected ContextMeasurementRoot value")
+	}
+}
+
+func TestMeasurementRootWithMeasurementRootPanic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	ctx := context.Background()
+	ctx = WithMeasurementRoot(ctx, nil)
+}


### PR DESCRIPTION
No hurry to do that externally, for now. Paves the way for
doing that quite easily, however.