### PR TITLE
[DATA CHANGE] Split the resolve event

### DIFF
--- a/internal/dialer/dnsdialer/dnsdialer.go
+++ b/internal/dialer/dnsdialer/dnsdialer.go
@@ -52,18 +52,21 @@ func (d *Dialer) DialContext(
 		conn, err = dialer.DialContext(ctx, network, address)
 		return
 	}
-	start := time.Now()
+	root.Handler.OnMeasurement(model.Measurement{
+		ResolveStart: &model.ResolveStartEvent{
+			DialID:   dialID,
+			Hostname: onlyhost,
+			Time:     time.Now().Sub(root.Beginning),
+		},
+	})
 	var addrs []string
 	addrs, err = d.resolver.LookupHost(ctx, onlyhost)
-	stop := time.Now()
 	root.Handler.OnMeasurement(model.Measurement{
-		Resolve: &model.ResolveEvent{
+		ResolveDone: &model.ResolveDoneEvent{
 			Addresses: addrs,
 			DialID:    dialID,
-			Duration:  stop.Sub(start),
 			Error:     err,
-			Hostname:  onlyhost,
-			Time:      stop.Sub(root.Beginning),
+			Time:      time.Now().Sub(root.Beginning),
 		},
 	})
 	if err != nil {

--- a/model/model.go
+++ b/model/model.go
@@ -148,13 +148,18 @@ type ReadEvent struct {
 	Time     time.Duration
 }
 
-// ResolveEvent is emitted when resolver.LookupHost returns.
-type ResolveEvent struct {
+// ResolveStartEvent is emitted when resolver.LookupHost begins.
+type ResolveStartEvent struct {
+	DialID   int64
+	Hostname string
+	Time     time.Duration
+}
+
+// ResolveDoneEvent is emitted when resolver.LookupHost returns.
+type ResolveDoneEvent struct {
 	Addresses []string
 	DialID    int64
-	Duration  time.Duration
 	Error     error
-	Hostname  string
 	Time      time.Duration
 }
 
@@ -228,10 +233,17 @@ type WriteEvent struct {
 // time a Measurement will only contain a single event. When a Measurement
 // contains an event, the corresponding pointer is non nil.
 type Measurement struct {
-	Close    *CloseEvent    `json:",omitempty"`
-	Connect  *ConnectEvent  `json:",omitempty"`
-	DNSQuery *DNSQueryEvent `json:",omitempty"`
-	DNSReply *DNSReplyEvent `json:",omitempty"`
+	// DNS
+	ResolveStart *ResolveStartEvent `json:",omitempty"`
+	ResolveDone  *ResolveDoneEvent  `json:",omitempty"`
+	DNSQuery     *DNSQueryEvent     `json:",omitempty"`
+	DNSReply     *DNSReplyEvent     `json:",omitempty"`
+
+	// Syscalls
+	Connect *ConnectEvent `json:",omitempty"`
+	Read    *ReadEvent    `json:",omitempty"`
+	Write   *WriteEvent   `json:",omitempty"`
+	Close   *CloseEvent   `json:",omitempty"`
 
 	// TLS events
 	TLSHandshakeStart *TLSHandshakeStartEvent `json:",omitempty"`
@@ -246,11 +258,9 @@ type Measurement struct {
 	HTTPResponseStart      *HTTPResponseStartEvent      `json:",omitempty"`
 	HTTPRoundTripDone      *HTTPRoundTripDoneEvent      `json:",omitempty"`
 
+	// HTTP body events
 	HTTPResponseBodyPart *HTTPResponseBodyPartEvent `json:",omitempty"`
 	HTTPResponseDone     *HTTPResponseDoneEvent     `json:",omitempty"`
-	Read                 *ReadEvent                 `json:",omitempty"`
-	Resolve              *ResolveEvent              `json:",omitempty"`
-	Write                *WriteEvent                `json:",omitempty"`
 }
 
 // Handler handles measurement events.


### PR DESCRIPTION
Lots of stuff may happen between the beginning and the end of a
resolver, therefore, it makes sense to split.