### PR TITLE
[DATA CHANGE] HTTPRequestDone: add error

### DIFF
--- a/internal/httptransport/tracetripper/tracetripper.go
+++ b/internal/httptransport/tracetripper/tracetripper.go
@@ -98,6 +98,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		WroteRequest: func(info httptrace.WroteRequestInfo) {
 			root.Handler.OnMeasurement(model.Measurement{
 				HTTPRequestDone: &model.HTTPRequestDoneEvent{
+					Error:         info.Err,
 					Time:          time.Now().Sub(root.Beginning),
 					TransactionID: tid,
 				},

--- a/model/model.go
+++ b/model/model.go
@@ -97,6 +97,7 @@ type HTTPRequestHeadersDoneEvent struct {
 
 // HTTPRequestDoneEvent is emitted when we have sent the body.
 type HTTPRequestDoneEvent struct {
+	Error         error
 	Time          time.Duration
 	TransactionID int64
 }


### PR DESCRIPTION
This is useful to distinguish the case where the error was in
sending the request from the one where it was instead in receiving
the response. It is a small aspect, but still useful.