### PR TITLE
Cross reference dials and transactions

### DIFF
--- a/handlers/logger/logger.go
+++ b/handlers/logger/logger.go
@@ -33,9 +33,10 @@ func (h *Handler) OnMeasurement(m model.Measurement) {
 	// DNS
 	if m.ResolveStart != nil {
 		h.logger.WithFields(log.Fields{
-			"dialID":   m.ResolveStart.DialID,
-			"elapsed":  m.ResolveStart.Time,
-			"hostname": m.ResolveStart.Hostname,
+			"dialID":        m.ResolveStart.DialID,
+			"elapsed":       m.ResolveStart.Time,
+			"hostname":      m.ResolveStart.Hostname,
+			"transactionID": m.ResolveStart.TransactionID,
 		}).Debug("dns: resolve domain name")
 	}
 	if m.ResolveDone != nil {
@@ -105,6 +106,7 @@ func (h *Handler) OnMeasurement(m model.Measurement) {
 	// HTTP round trip
 	if m.HTTPRoundTripStart != nil {
 		h.logger.WithFields(log.Fields{
+			"dialID":        m.HTTPRoundTripStart.DialID,
 			"elapsed":       m.HTTPRoundTripStart.Time,
 			"method":        m.HTTPRoundTripStart.Method,
 			"transactionID": m.HTTPRoundTripStart.TransactionID,

--- a/internal/dialid/dialid.go
+++ b/internal/dialid/dialid.go
@@ -1,0 +1,23 @@
+package dialid
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type contextkey struct{}
+
+var id int64
+
+// WithDialID returns a copy of ctx with DialID
+func WithDialID(ctx context.Context) context.Context {
+	return context.WithValue(
+		ctx, contextkey{}, atomic.AddInt64(&id, 1),
+	)
+}
+
+// ContextDialID returns the DialID of the context, or zero
+func ContextDialID(ctx context.Context) int64 {
+	id, _ := ctx.Value(contextkey{}).(int64)
+	return id
+}

--- a/internal/dialid/dialid_test.go
+++ b/internal/dialid/dialid_test.go
@@ -1,0 +1,24 @@
+package dialid
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIntegration(t *testing.T) {
+	ctx := context.Background()
+	id := ContextDialID(ctx)
+	if id != 0 {
+		t.Fatal("unexpected ID for empty context")
+	}
+	ctx = WithDialID(ctx)
+	id = ContextDialID(ctx)
+	if id != 1 {
+		t.Fatal("expected ID equal to 1")
+	}
+	ctx = WithDialID(ctx)
+	id = ContextDialID(ctx)
+	if id != 2 {
+		t.Fatal("expected ID equal to 2")
+	}
+}

--- a/internal/httptransport/bodyreader/bodyreader.go
+++ b/internal/httptransport/bodyreader/bodyreader.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ooni/netx/internal/httptransport/transactioner"
+	"github.com/ooni/netx/internal/transactionid"
 	"github.com/ooni/netx/model"
 )
 
@@ -34,7 +34,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	resp.Body = &bodyWrapper{
 		ReadCloser: resp.Body,
 		root:       model.ContextMeasurementRootOrDefault(req.Context()),
-		tid:        transactioner.ContextTransactionID(req.Context()),
+		tid:        transactionid.ContextTransactionID(req.Context()),
 	}
 	return
 }

--- a/internal/httptransport/tracetripper/tracetripper.go
+++ b/internal/httptransport/tracetripper/tracetripper.go
@@ -8,7 +8,8 @@ import (
 	"time"
 
 	"github.com/ooni/netx/internal/connid"
-	"github.com/ooni/netx/internal/httptransport/transactioner"
+	"github.com/ooni/netx/internal/dialid"
+	"github.com/ooni/netx/internal/transactionid"
 	"github.com/ooni/netx/model"
 )
 
@@ -29,9 +30,10 @@ func New(roundTripper http.RoundTripper) *Transport {
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	root := model.ContextMeasurementRootOrDefault(req.Context())
 
-	tid := transactioner.ContextTransactionID(req.Context())
+	tid := transactionid.ContextTransactionID(req.Context())
 	root.Handler.OnMeasurement(model.Measurement{
 		HTTPRoundTripStart: &model.HTTPRoundTripStartEvent{
+			DialID:        dialid.ContextDialID(req.Context()),
 			Method:        req.Method,
 			Time:          time.Now().Sub(root.Beginning),
 			TransactionID: tid,

--- a/internal/httptransport/transactioner/transactioner.go
+++ b/internal/httptransport/transactioner/transactioner.go
@@ -2,27 +2,10 @@
 package transactioner
 
 import (
-	"context"
 	"net/http"
-	"sync/atomic"
+
+	"github.com/ooni/netx/internal/transactionid"
 )
-
-type contextkey struct{}
-
-var id int64
-
-// WithTransactionID returns a copy of ctx with TransactionID
-func WithTransactionID(ctx context.Context) context.Context {
-	return context.WithValue(
-		ctx, contextkey{}, atomic.AddInt64(&id, 1),
-	)
-}
-
-// ContextTransactionID returns the TransactionID of the context, or zero
-func ContextTransactionID(ctx context.Context) int64 {
-	id, _ := ctx.Value(contextkey{}).(int64)
-	return id
-}
 
 // Transport performs single HTTP transactions.
 type Transport struct {
@@ -39,8 +22,9 @@ func New(roundTripper http.RoundTripper) *Transport {
 // RoundTrip executes a single HTTP transaction, returning
 // a Response for the provided Request.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	ctx := WithTransactionID(req.Context())
-	return t.roundTripper.RoundTrip(req.WithContext(ctx))
+	return t.roundTripper.RoundTrip(req.WithContext(
+		transactionid.WithTransactionID(req.Context()),
+	))
 }
 
 // CloseIdleConnections closes the idle connections.

--- a/internal/httptransport/transactioner/transactioner_test.go
+++ b/internal/httptransport/transactioner/transactioner_test.go
@@ -4,6 +4,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/ooni/netx/internal/transactionid"
 )
 
 type transport struct {
@@ -13,7 +15,7 @@ type transport struct {
 
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
-	if id := ContextTransactionID(ctx); id == 0 {
+	if id := transactionid.ContextTransactionID(ctx); id == 0 {
 		t.t.Fatal("transaction ID not set")
 	}
 	return t.roundTripper.RoundTrip(req)

--- a/internal/transactionid/transactionid.go
+++ b/internal/transactionid/transactionid.go
@@ -1,0 +1,24 @@
+// Package transactionid contains code to share the transactionID
+package transactionid
+
+import (
+	"sync/atomic"
+	"context"
+)
+
+type contextkey struct{}
+
+var id int64
+
+// WithTransactionID returns a copy of ctx with TransactionID
+func WithTransactionID(ctx context.Context) context.Context {
+	return context.WithValue(
+		ctx, contextkey{}, atomic.AddInt64(&id, 1),
+	)
+}
+
+// ContextTransactionID returns the TransactionID of the context, or zero
+func ContextTransactionID(ctx context.Context) int64 {
+	id, _ := ctx.Value(contextkey{}).(int64)
+	return id
+}

--- a/internal/transactionid/transactionid_test.go
+++ b/internal/transactionid/transactionid_test.go
@@ -1,0 +1,25 @@
+
+package transactionid
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIntegration(t *testing.T) {
+	ctx := context.Background()
+	id := ContextTransactionID(ctx)
+	if id != 0 {
+		t.Fatal("unexpected ID for empty context")
+	}
+	ctx = WithTransactionID(ctx)
+	id = ContextTransactionID(ctx)
+	if id != 1 {
+		t.Fatal("expected ID equal to 1")
+	}
+	ctx = WithTransactionID(ctx)
+	id = ContextTransactionID(ctx)
+	if id != 2 {
+		t.Fatal("expected ID equal to 2")
+	}
+}

--- a/internal/transactionid/transactionid_test.go
+++ b/internal/transactionid/transactionid_test.go
@@ -1,4 +1,3 @@
-
 package transactionid
 
 import (

--- a/model/model.go
+++ b/model/model.go
@@ -75,6 +75,7 @@ type HTTPConnectionReadyEvent struct {
 
 // HTTPRoundTripStartEvent is emitted when we start the round trip.
 type HTTPRoundTripStartEvent struct {
+	DialID        int64
 	Method        string
 	Time          time.Duration
 	TransactionID int64
@@ -151,9 +152,10 @@ type ReadEvent struct {
 
 // ResolveStartEvent is emitted when resolver.LookupHost begins.
 type ResolveStartEvent struct {
-	DialID   int64
-	Hostname string
-	Time     time.Duration
+	DialID        int64
+	Hostname      string
+	Time          time.Duration
+	TransactionID int64
 }
 
 // ResolveDoneEvent is emitted when resolver.LookupHost returns.


### PR DESCRIPTION
1. make sure that, when we start a DoH transaction to resolve a
domain name, we know which dial originated it.

2. make sure that, when we dial, we always know what is the
transaction that triggered us, if any (otherwise, ID == zero).

3. while there, always emit resolve, also for IP addresses, so
we have a place where to store the origin transactionID for the
common case like `udp://8.8.8.8:53`. This solution has been
preferred to introducing another event.