### PR TITLE
Make events actionable for OONI's nervous system

### DIFF
--- a/handlers/logger/logger.go
+++ b/handlers/logger/logger.go
@@ -59,10 +59,11 @@ func (h *Handler) OnMeasurement(m model.Measurement) {
 	}
 	if m.ResolveDone != nil {
 		h.logger.WithFields(log.Fields{
-			"addresses": m.ResolveDone.Addresses,
-			"dialID":    m.ResolveDone.DialID,
-			"elapsed":   m.ResolveDone.DurationSinceBeginning,
-			"error":     m.ResolveDone.Error,
+			"addresses":     m.ResolveDone.Addresses,
+			"dialID":        m.ResolveDone.DialID,
+			"elapsed":       m.ResolveDone.DurationSinceBeginning,
+			"error":         m.ResolveDone.Error,
+			"transactionID": m.ResolveDone.TransactionID,
 		}).Debug("dns: resolution done")
 	}
 
@@ -76,6 +77,7 @@ func (h *Handler) OnMeasurement(m model.Measurement) {
 			"error":         m.Connect.Error,
 			"network":       m.Connect.Network,
 			"remoteAddress": m.Connect.RemoteAddress,
+			"transactionID": m.Connect.TransactionID,
 		}).Debug("net: connect done")
 	}
 	if m.Read != nil {

--- a/internal/dialer/dialerbase/dialerbase.go
+++ b/internal/dialer/dialerbase/dialerbase.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ooni/netx/internal/connid"
 	"github.com/ooni/netx/internal/dialer/connx"
 	"github.com/ooni/netx/internal/errwrapper"
+	"github.com/ooni/netx/internal/transactionid"
 	"github.com/ooni/netx/model"
 )
 
@@ -59,6 +60,7 @@ func (d *Dialer) DialContext(
 		Error:  err,
 	}.MaybeBuild()
 	connID := safeConnID(network, conn)
+	txID := transactionid.ContextTransactionID(ctx)
 	d.handler.OnMeasurement(model.Measurement{
 		Connect: &model.ConnectEvent{
 			ConnID:                 connID,
@@ -66,8 +68,9 @@ func (d *Dialer) DialContext(
 			DurationSinceBeginning: stop.Sub(d.beginning),
 			Error:                  err,
 			Network:                network,
-			RemoteAddress:          safeRemoteAddress(conn),
+			RemoteAddress:          address,
 			SyscallDuration:        stop.Sub(start),
+			TransactionID:          txID,
 		},
 	})
 	if err != nil {
@@ -84,13 +87,6 @@ func (d *Dialer) DialContext(
 func safeLocalAddress(conn net.Conn) (s string) {
 	if conn != nil && conn.LocalAddr() != nil {
 		s = conn.LocalAddr().String()
-	}
-	return
-}
-
-func safeRemoteAddress(conn net.Conn) (s string) {
-	if conn != nil && conn.RemoteAddr() != nil {
-		s = conn.RemoteAddr().String()
 	}
 	return
 }

--- a/internal/dialer/dnsdialer/dnsdialer.go
+++ b/internal/dialer/dnsdialer/dnsdialer.go
@@ -68,6 +68,8 @@ func (d *Dialer) DialContext(
 			DialID:                 dialID,
 			DurationSinceBeginning: time.Now().Sub(root.Beginning),
 			Error:                  err,
+			Hostname:               onlyhost,
+			TransactionID:          txID,
 		},
 	})
 	if err != nil {

--- a/model/model.go
+++ b/model/model.go
@@ -159,6 +159,10 @@ type ConnectEvent struct {
 	// SyscallDuration is the number of nanoseconds we were
 	// blocked waiting for the syscall to return.
 	SyscallDuration time.Duration
+
+	// TransactionID is the ID of the HTTP transaction that caused the
+	// current dial to run, or zero if there's no such transaction.
+	TransactionID int64 `json:",omitempty"`
 }
 
 // DNSQueryEvent is emitted when we send a DNS query.
@@ -414,6 +418,13 @@ type ResolveDoneEvent struct {
 
 	// Error is the result of the dial operation.
 	Error error
+
+	// Hostname is the domain name to resolve.
+	Hostname string
+
+	// TransactionID is the ID of the HTTP transaction that caused the
+	// current dial to run, or zero if there's no such transaction.
+	TransactionID int64 `json:",omitempty"`
 }
 
 // X509Certificate is an x.509 certificate.


### PR DESCRIPTION
After trial and error, I have determined that, in general, to decide
whether we need follow-up measurements, we need just the result of
four events in the HTTP round trip:

- RESOLVE_DONE
- CONNECT
- HANDSHAKE_DONE
- ROUND_TRIP_DONE

In some cases it may be possible to run operations inline while in
others it's probably best to run concurrently or later.

Regardless of the implementation strategy, this diff makes sure that
by combining this four events only, we have enough information to
conclude whether to trigger more measurements.

This conclusion is based on my analysis using ooni/jafar, it may be
of course that later we'll need to tweak this a bit.

I've been doing refactoring for quite some time to prepare this.

Master issue: https://github.com/ooni/probe-engine/issues/87