### PR TITLE
dnsdialer: allow to divert lookuphost

### DIFF
--- a/internal/dialer/dnsdialer/dnsdialer.go
+++ b/internal/dialer/dnsdialer/dnsdialer.go
@@ -106,5 +106,9 @@ func (d *Dialer) lookupHost(ctx context.Context, hostname string) ([]string, err
 	if net.ParseIP(hostname) != nil {
 		return []string{hostname}, nil
 	}
+	root := model.ContextMeasurementRootOrDefault(ctx)
+	if root.LookupHost != nil {
+		return root.LookupHost(ctx, hostname)
+	}
 	return d.resolver.LookupHost(ctx, hostname)
 }

--- a/internal/dialer/dnsdialer/dnsdialer_test.go
+++ b/internal/dialer/dnsdialer/dnsdialer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/model"
 )
 
@@ -92,4 +93,23 @@ func TestReduceErrors(t *testing.T) {
 			t.Fatal("wrong result")
 		}
 	})
+}
+
+func TestIntegrationDivertLookupHost(t *testing.T) {
+	dialer := newdialer()
+	root := &model.MeasurementRoot{
+		Beginning: time.Now(),
+		Handler:   handlers.NoHandler,
+		LookupHost: func(ctx context.Context, hostname string) ([]string, error) {
+			return nil, errors.New("mocked error")
+		},
+	}
+	ctx := model.WithMeasurementRoot(context.Background(), root)
+	conn, err := dialer.DialContext(ctx, "tcp", "google.com:443")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if conn != nil {
+		t.Fatal("expected a nil conn here")
+	}
 }

--- a/model/model.go
+++ b/model/model.go
@@ -590,6 +590,10 @@ type MeasurementRoot struct {
 
 	// Handler is the handler that will handle events.
 	Handler Handler
+
+	// LookupHost allows to override the host lookup for all the request
+	// and dials that use this measurement root.
+	LookupHost func(ctx context.Context, hostname string) ([]string, error)
 }
 
 type measurementRootContextKey struct{}


### PR DESCRIPTION
A MeasurementRoot can contain an alternative LookupHost function
which may be used to bypass the usual chain.

This is also functional to the OONI reactive system.

See https://github.com/ooni/probe-engine/issues/87