### PR TITLE
Extend scoreboard to also track TLS handshake RST

### DIFF
--- a/internal/httptransport/tracetripper/tracetripper.go
+++ b/internal/httptransport/tracetripper/tracetripper.go
@@ -61,13 +61,17 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 				Error:         err,
 				TransactionID: tid,
 			}.MaybeBuild()
+			durationSinceBeginning := time.Now().Sub(root.Beginning)
+			root.X.Scoreboard.MaybeTLSHandshakeReset(
+				durationSinceBeginning, req.URL, err,
+			)
 			// Event emitted by net/http when DialTLS is not
 			// configured in the http.Transport
 			root.Handler.OnMeasurement(model.Measurement{
 				TLSHandshakeDone: &model.TLSHandshakeDoneEvent{
 					ConnectionState:        model.NewTLSConnectionState(state),
 					Error:                  err,
-					DurationSinceBeginning: time.Now().Sub(root.Beginning),
+					DurationSinceBeginning: durationSinceBeginning,
 					TransactionID:          tid,
 				},
 			})

--- a/x/nervousresolver/nervousresolver.go
+++ b/x/nervousresolver/nervousresolver.go
@@ -82,8 +82,8 @@ func (c *Resolver) LookupHost(ctx context.Context, hostname string) ([]string, e
 	root.X.Scoreboard.AddDNSBogonInfo(scoreboard.DNSBogonInfo{
 		Addresses:              addrs,
 		DurationSinceBeginning: durationSinceBeginning,
-		FollowupAction:         "retry using DoH resolver",
-		Hostname:               hostname,
+		Domain:                 hostname,
+		FallbackPlan:           "ignore_and_retry_with_doh",
 	})
 	value := bogonLookup{
 		Addresses: addrs,

--- a/x/scoreboard/scoreboard_test.go
+++ b/x/scoreboard/scoreboard_test.go
@@ -1,9 +1,52 @@
-package scoreboard
+// must be another package to avoid import cycle
+package scoreboard_test
 
-import "testing"
+import (
+	"errors"
+	"net"
+	"net/url"
+	"testing"
 
-func TestIntegration(t *testing.T) {
-	board := &Board{}
-	board.AddDNSBogonInfo(DNSBogonInfo{})
+	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/x/scoreboard"
+)
+
+func TestIntegrationDNSBogon(t *testing.T) {
+	board := &scoreboard.Board{}
+	board.AddDNSBogonInfo(scoreboard.DNSBogonInfo{})
+	t.Log(board.Marshal())
+}
+
+func TestIntegrationTLSHandshakeResetNil(t *testing.T) {
+	board := &scoreboard.Board{}
+	board.MaybeTLSHandshakeReset(0, nil, nil)
+	t.Log(board.Marshal())
+}
+
+func TestIntegrationTLSHandshakeResetNotReset(t *testing.T) {
+	board := &scoreboard.Board{}
+	board.MaybeTLSHandshakeReset(0, nil, errors.New("antani"))
+	t.Log(board.Marshal())
+}
+
+func TestIntegrationTLSHandshakeResetIsReset(t *testing.T) {
+	board := &scoreboard.Board{}
+	board.MaybeTLSHandshakeReset(0, &url.URL{}, errors.New("connection_reset"))
+	t.Log(board.Marshal())
+}
+
+func TestIntegrationTLSHandshakeResetIsResetWithAddr(t *testing.T) {
+	board := &scoreboard.Board{}
+	board.MaybeTLSHandshakeReset(
+		0, &url.URL{}, &model.ErrWrapper{
+			Failure: "connection_reset",
+			WrappedErr: &net.OpError{
+				Addr: &net.TCPAddr{
+					IP:   net.IPv4(8, 8, 8, 8),
+					Port: 53,
+				},
+			},
+		},
+	)
 	t.Log(board.Marshal())
 }


### PR DESCRIPTION
The scoreboard package will probably benefit from some more
precise unit testing with respect to returned keys.

Work related to ooni/probe-engine#87