### PR TITLE
Make nervous system data more immediately actionable

### DIFF
--- a/cmd/httpclient/main.go
+++ b/cmd/httpclient/main.go
@@ -115,6 +115,9 @@ func fetch(client *http.Client, url string) (err error) {
 		Handler:    makehandler(),
 		LookupHost: nervousresolver.Default.LookupHost,
 	}
+	defer func() {
+		fmt.Printf("%s\n", root.X.Scoreboard.Marshal())
+	}()
 	ctx := model.WithMeasurementRoot(req.Context(), root)
 	req = req.WithContext(ctx)
 	resp, err := client.Do(req)

--- a/model/model.go
+++ b/model/model.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/ooni/netx/x/scoreboard"
 )
 
 // Measurement contains zero or more events. Do not assume that at any
@@ -624,6 +625,12 @@ type MeasurementRoot struct {
 	// LookupHost allows to override the host lookup for all the request
 	// and dials that use this measurement root.
 	LookupHost func(ctx context.Context, hostname string) ([]string, error)
+
+	// X contains experimental extensions. You are welcome to use
+	// the code in here. Just know we may change APIs often.
+	X struct {
+		Scoreboard scoreboard.Board
+	}
 }
 
 type measurementRootContextKey struct{}

--- a/x/scoreboard/scoreboard.go
+++ b/x/scoreboard/scoreboard.go
@@ -1,0 +1,40 @@
+// Package scoreboard contains the measurements scoreboard.
+//
+// This is currently experimental code.
+package scoreboard
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// Board contains what we learned during measurements.
+type Board struct {
+	DNSBogonInfo []DNSBogonInfo
+	mu           sync.Mutex
+}
+
+// DNSBogonInfo contains info on bogon replies received when
+// using the default resolver. To perform this measurement,
+// you need to divert the resolver to nervousresolver.Resolver
+// using MeasurementRoot.LookupHost.
+type DNSBogonInfo struct {
+	Addresses              []string
+	DurationSinceBeginning time.Duration
+	FollowupAction         string
+	Hostname               string
+}
+
+// AddDNSBogonInfo adds info on a DNS bogon reply
+func (b *Board) AddDNSBogonInfo(info DNSBogonInfo) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.DNSBogonInfo = append(b.DNSBogonInfo, info)
+}
+
+// Marshal marshals the board in JSON format.
+func (b *Board) Marshal() string {
+	data, _ := json.Marshal(b)
+	return string(data)
+}

--- a/x/scoreboard/scoreboard_test.go
+++ b/x/scoreboard/scoreboard_test.go
@@ -1,0 +1,9 @@
+package scoreboard
+
+import "testing"
+
+func TestIntegration(t *testing.T) {
+	board := &Board{}
+	board.AddDNSBogonInfo(DNSBogonInfo{})
+	t.Log(board.Marshal())
+}


### PR DESCRIPTION
Implement a scoreboard and write there what we see. The follow up
action may or may not be required.

This is also functional to the OONI reactive system.

See ooni/probe-engine#87