### PR TITLE
nervousresolver: fix processing of bogons

### DIFF
--- a/x/nervousresolver/nervousresolver_test.go
+++ b/x/nervousresolver/nervousresolver_test.go
@@ -41,6 +41,26 @@ func TestIntegrationMixed(t *testing.T) {
 	if len(addrs) < 1 {
 		t.Fatal("expected an address here")
 	}
+	if resolver.bogonsCount != 1 {
+		t.Fatal("unexpected number of bogons seen")
+	}
+}
+
+func TestIntegrationGood(t *testing.T) {
+	resolver := New(
+		&fakeresolverbogon{
+			Resolver: new(net.Resolver),
+			reply:    []string{"8.8.8.8"},
+		},
+		new(net.Resolver),
+	)
+	addrs, err := resolver.LookupHost(context.Background(), "www.kernel.org")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) < 1 {
+		t.Fatal("expected an address here")
+	}
 	if resolver.bogonsCount != 0 {
 		t.Fatal("unexpected number of bogons seen")
 	}


### PR DESCRIPTION
For now let us limit to act if we see any bogon. If we see at
least one, we cannot trust the upstream DNS. If we don't see any,
or we see an error, for now don't use the secondary resolver as
this complicates making other techniques possible.

I believe we may reconsider the latter choice when we have
some more experience with this part of the tree and we have
run more testing with jafar and/or in the field.