### PR TITLE
Rework nervous resolver and make it opt-in

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 | Author       | Simone Basso |
 |--------------|--------------|
-| Last-Updated | 2019-10-27   |
+| Last-Updated | 2019-10-29   |
 | Status       | approved     |
 
 ## Introduction
@@ -188,8 +188,8 @@ then pass to code that needs it `HTTPClient` as the real
 `*http.Client` instance.
 
 To configure our `*Client` instance, one could use the
-`ConfigureDNS`, `SetCABundle` and `ForceSpecificSNI`
-methods. They should all be called before using the
+`ConfigureDNS`, `SetCABundle`, `ForceSpecificSNI`,
+and `SetResolver` methods. They should all be called before using the
 `HTTPClient` field, as they'll not be goroutine safe.
 
 ```Go
@@ -213,6 +213,12 @@ func (c *Client) ConfigureDNS(network, address string) error
 
 The `ConfigureDNS` method will behave exactly like the
 `ConfigureDNS` method of `netx.Resolver` (see below).
+
+```Go
+func (c *Client) SetResolver(r model.DNSResolver) error
+```
+
+Also `SetResolver` is described below.
 
 ```Go
 func (c *Client) SetProxyFunc(f func(*Request) (*url.URL, error) error
@@ -267,7 +273,9 @@ func fetchURL(URL string) (*http.Response, error) {
 }
 ```
 
-Of course, you should probably use your handler there.
+This will cause code to use `root` for all requests
+using the specific `ctx`. This allows you to naturally
+organize events in different groups.
 
 ### The github.com/ooni/netx package
 
@@ -304,15 +312,19 @@ The `netx.Dialer` will also feature the following functions, to
 be called before using the dialer:
 
 ```Go
-func (c *Client) ConfigureDNS(network, address string) error
+func (d *Dialer) ConfigureDNS(network, address string) error
 ```
 
 ```Go
-func (c *Client) SetCABundle(path string) error
+func (d *Dialer) SetCABundle(path string) error
 ```
 
 ```Go
-func (c *Client) ForceSpecificSNI(sni string) error
+func (d *Dialer) ForceSpecificSNI(sni string) error
+```
+
+```Go
+func (d *Dialer) SetResolver(r model.DNSResolver) error
 ```
 
 `SetCABundle` and `ForceSpecificSNI` behave exactly like the same
@@ -348,7 +360,8 @@ URL of a DNS over HTTPS server to use. We will observe all
 events, including the TLS handshake and HTTP events, the
 DNS messages sent and received, etc.
 
-Lastly, `netx.Dialer` will expose this API:
+As far as `SetResolver` is concerned, this is a way to
+set an arbitrary resolver. To create resolvers use:
 
 ```Go
 func (d *Dialer) NewResolver(network, address string) (model.DNSResolver, error)
@@ -357,3 +370,7 @@ func (d *Dialer) NewResolver(network, address string) (model.DNSResolver, error)
 The arguments have the same meaning of `ConfigureDNS` and
 the will return an interface replacement for `net.Resolver`
 as described below.
+
+### The github.com/ooni/netx/x package
+
+This is for experimental stuff.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -364,7 +364,8 @@ As far as `SetResolver` is concerned, this is a way to
 set an arbitrary resolver. To create resolvers use:
 
 ```Go
-func (d *Dialer) NewResolver(network, address string) (model.DNSResolver, error)
+func NewResolver(handler model.Handler,
+    network, address string) (model.DNSResolver, error)
 ```
 
 The arguments have the same meaning of `ConfigureDNS` and

--- a/cmd/httpclient/main.go
+++ b/cmd/httpclient/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ooni/netx/httpx"
 	"github.com/ooni/netx/model"
 	"github.com/ooni/netx/x/logger"
+	"github.com/ooni/netx/x/nervousresolver"
 	"github.com/ooni/netx/x/porcelain"
 )
 
@@ -74,6 +75,7 @@ func mainfunc() (err error) {
 		fmt.Printf("  ./httpclient -dns-server dot://dns.quad9.net\n")
 		fmt.Printf("  ./httpclient -dns-server dot://1.1.1.1:853\n")
 		fmt.Printf("  ./httpclient -dns-server https://cloudflare-dns.com/dns-query\n")
+		fmt.Printf("  ./httpclient -dns-server x-nervous:///\n")
 		return nil
 	}
 
@@ -90,6 +92,10 @@ func mainfunc() (err error) {
 		err = client.ConfigureDNS("dot", urlDNSServer.Host)
 	} else if urlDNSServer.Scheme == "https" {
 		err = client.ConfigureDNS("doh", urlDNSServer.String())
+	} else if urlDNSServer.Scheme == "x-nervous" {
+		// This is a new, experimental resolver, so it's using a more
+		// direct and simple API for configuring a resolver.
+		client.SetResolver(nervousresolver.Default)
 	} else if *flagDNSServer != "" {
 		err = errors.New("invalid -dns-server argument")
 	}

--- a/cmd/httpclient/main_test.go
+++ b/cmd/httpclient/main_test.go
@@ -81,6 +81,17 @@ func TestDoHTransport(t *testing.T) {
 	}
 }
 
+func TestNervousTransport(t *testing.T) {
+	*flagDNSServer = "x-nervous:///"
+	defer func() {
+		*flagDNSServer = ""
+	}()
+	err := mainfunc()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestInvalidTransport(t *testing.T) {
 	*flagDNSServer = "invalid"
 	defer func() {

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -44,6 +44,11 @@ func (t *Transport) ConfigureDNS(network, address string) error {
 	return t.dialer.ConfigureDNS(network, address)
 }
 
+// SetResolver is exactly like netx.Dialer.SetResolver.
+func (t *Transport) SetResolver(r model.DNSResolver) {
+	t.dialer.SetResolver(r)
+}
+
 // SetCABundle internally calls netx.Dialer.SetCABundle and
 // therefore it has the same caveats and limitations.
 func (t *Transport) SetCABundle(path string) error {
@@ -81,6 +86,11 @@ func NewClient(handler model.Handler) *Client {
 // therefore it has the same caveats and limitations.
 func (c *Client) ConfigureDNS(network, address string) error {
 	return c.Transport.ConfigureDNS(network, address)
+}
+
+// SetResolver internally calls netx.Dialer.SetResolver
+func (c *Client) SetResolver(r model.DNSResolver) {
+	c.Transport.SetResolver(r)
 }
 
 // SetCABundle internally calls netx.Dialer.SetCABundle and

--- a/httpx/httpx_test.go
+++ b/httpx/httpx_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/httpx"
+	"github.com/ooni/netx/x/nervousresolver"
 )
 
 func TestIntegration(t *testing.T) {
@@ -26,6 +27,20 @@ func TestIntegration(t *testing.T) {
 	}
 }
 
+func TestIntegrationSetResolver(t *testing.T) {
+	client := httpx.NewClient(handlers.NoHandler)
+	defer client.Transport.CloseIdleConnections()
+	client.SetResolver(nervousresolver.Default)
+	resp, err := client.HTTPClient.Get("https://www.google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 func TestSetCABundle(t *testing.T) {
 	client := httpx.NewClient(handlers.NoHandler)
 	err := client.SetCABundle("../testdata/cacert.pem")

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -112,6 +112,11 @@ func (d *Dialer) ConfigureDNS(network, address string) error {
 	return err
 }
 
+// SetResolver implements netx.Dialer.SetResolver.
+func (d *Dialer) SetResolver(r model.DNSResolver) {
+	d.Resolver = r
+}
+
 func newHTTPClientForDoH(beginning time.Time, handler model.Handler) *http.Client {
 	transport := NewHTTPTransport(beginning, handler, NewDialer(beginning, handler))
 	return &http.Client{Transport: transport}

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -23,6 +23,16 @@ func TestIntegrationDial(t *testing.T) {
 	conn.Close()
 }
 
+func TestIntegrationDialWithCustomResolver(t *testing.T) {
+	dialer := NewDialer(time.Now(), handlers.NoHandler)
+	dialer.SetResolver(new(net.Resolver))
+	conn, err := dialer.Dial("tcp", "www.google.com:80")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+}
+
 func TestIntegrationDialTLS(t *testing.T) {
 	dialer := NewDialer(time.Now(), handlers.NoHandler)
 	conn, err := dialer.DialTLS("tcp", "www.google.com:443")

--- a/netx.go
+++ b/netx.go
@@ -62,6 +62,12 @@ func (d *Dialer) ConfigureDNS(network, address string) error {
 	return d.dialer.ConfigureDNS(network, address)
 }
 
+// SetResolver is a more flexible way of configuring a resolver
+// that should perhaps be used instead of ConfigureDNS.
+func (d *Dialer) SetResolver(r model.DNSResolver) {
+	d.dialer.SetResolver(r)
+}
+
 // Dial creates a TCP or UDP connection. See net.Dial docs.
 func (d *Dialer) Dial(network, address string) (net.Conn, error) {
 	return d.dialer.Dial(network, address)
@@ -80,14 +86,19 @@ func (d *Dialer) DialTLS(network, address string) (conn net.Conn, err error) {
 	return d.dialer.DialTLS(network, address)
 }
 
-// NewResolver returns a new resolver using this Dialer as dialer for
-// creating new network connections used for resolving. The arguments have
-// the same meaning of ConfigureDNS. The returned resolver will not be
-// used by this Dialer, however the network operations that it performs
-// (e.g. creating a new connection) will use this Dialer. This is why
-// NewResolver is a method rather than being just a free function.
+// NewResolver returns a new resolver using the same handler of this
+// Dialer. The arguments have the same meaning of ConfigureDNS. The
+// returned resolver will not be used by this Dialer, and will not use
+// this Dialer as well. The fact that it's a method of Dialer rather
+// than an independent method is an historical oddity. There is also a
+// standalone NewResolver factory and you should probably use it.
 func (d *Dialer) NewResolver(network, address string) (model.DNSResolver, error) {
 	return internal.NewResolver(d.dialer.Beginning, d.dialer.Handler, network, address)
+}
+
+// NewResolver is a standalone Dialer.NewResolver
+func NewResolver(handler model.Handler, network, address string) (model.DNSResolver, error) {
+	return internal.NewResolver(time.Now(), handler, network, address)
 }
 
 // SetCABundle configures the dialer to use a specific CA bundle. This

--- a/netx_test.go
+++ b/netx_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ooni/netx"
 	"github.com/ooni/netx/handlers"
+	"github.com/ooni/netx/x/nervousresolver"
 )
 
 func TestIntegrationDialer(t *testing.T) {
@@ -35,9 +36,45 @@ func TestIntegrationDialer(t *testing.T) {
 	conn.Close()
 }
 
+func TestIntegrationDialerWithSetResolver(t *testing.T) {
+	dialer := netx.NewDialer(handlers.NoHandler)
+	dialer.SetResolver(nervousresolver.Default)
+	conn, err := dialer.Dial("tcp", "www.google.com:80")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+	conn, err = dialer.DialContext(
+		context.Background(), "tcp", "www.google.com:80",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+	conn, err = dialer.DialTLS("tcp", "www.google.com:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+}
+
 func TestIntegrationResolver(t *testing.T) {
 	dialer := netx.NewDialer(handlers.NoHandler)
 	resolver, err := dialer.NewResolver("tcp", "1.1.1.1:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addrs, err := resolver.LookupHost(context.Background(), "ooni.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) < 1 {
+		t.Fatal("No addresses returned")
+	}
+}
+
+func TestIntegrationStandaloneResolver(t *testing.T) {
+	resolver, err := netx.NewResolver(handlers.NoHandler, "tcp", "1.1.1.1:53")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/x/nervousresolver/nervousresolver.go
+++ b/x/nervousresolver/nervousresolver.go
@@ -67,11 +67,12 @@ type bogonLookup struct {
 // TODO(bassosimone): integrate more ideas from the design doc.
 func (c *Resolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
 	addrs, err := c.primary.LookupHost(ctx, hostname)
-	if err == nil {
-		for _, addr := range addrs {
-			if bogon.Check(addr) == true {
-				return c.detectedBogon(ctx, hostname, addrs)
-			}
+	if err != nil {
+		return c.secondary.LookupHost(ctx, hostname)
+	}
+	for _, addr := range addrs {
+		if bogon.Check(addr) == true {
+			return c.detectedBogon(ctx, hostname, addrs)
 		}
 	}
 	return addrs, err

--- a/x/porcelain/porcelain.go
+++ b/x/porcelain/porcelain.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/model"
-	"github.com/ooni/netx/x/nervousresolver"
 )
 
 // NewHTTPRequest is like http.NewRequest except that it also adds
@@ -18,9 +17,8 @@ func NewHTTPRequest(method, URL string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, URL, body)
 	if err == nil {
 		root := &model.MeasurementRoot{
-			Beginning:  time.Now(),
-			Handler:    handlers.NoHandler,
-			LookupHost: nervousresolver.Default.LookupHost,
+			Beginning: time.Now(),
+			Handler:   handlers.NoHandler,
 		}
 		ctx := model.WithMeasurementRoot(req.Context(), root)
 		req = req.WithContext(ctx)


### PR DESCRIPTION
I realised it was not a good idea to have it hidden and enabled
by default, as it prevented other kind of testing.

So, allow using it as opt-in.

Also, while there, make it better by using it whenever we fail
to query the DNS so to have more DNS robustness.

I think with this I'm near the bottom of my netx TODO list.