### PR TITLE
Adapt the HTTP configuration more to OONI needs

### DIFF
--- a/internal/httptransport/httptransport.go
+++ b/internal/httptransport/httptransport.go
@@ -27,6 +27,11 @@ func New(roundTripper http.RoundTripper) *Transport {
 // RoundTrip executes a single HTTP transaction, returning
 // a Response for the provided Request.
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	// Make sure we're not sending Go's default User-Agent
+	// if the user has configured no user agent
+	if req.Header.Get("User-Agent") == "" {
+		req.Header["User-Agent"] = nil
+	}
 	return t.roundTripper.RoundTrip(req)
 }
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -235,6 +235,8 @@ func NewHTTPTransport(
 	dialer *Dialer,
 ) *HTTPTransport {
 	baseTransport := &http.Transport{
+		// The following values are copied from Go 1.12 docs and match
+		// what should be used by the default transport
 		ExpectContinueTimeout: 1 * time.Second,
 		IdleConnTimeout:       90 * time.Second,
 		MaxIdleConns:          100,
@@ -259,6 +261,11 @@ func NewHTTPTransport(
 	// Better for Cloudflare DNS and also better because we have less
 	// noisy events and we can better understand what happened.
 	baseTransport.MaxConnsPerHost = 1
+	// The following (1) reduces the number of headers that Go will
+	// automatically send for us and (2) ensures that we always receive
+	// back the true headers, such as Content-Length. This change is
+	// functional to OONI's goal of observing the network.
+	baseTransport.DisableCompression = true
 	return &HTTPTransport{
 		Transport:    baseTransport,
 		Handler:      handler,


### PR DESCRIPTION
We need to observe real headers, so reduce the magic performed
under the hood by Go. The really good thing would be to be able
to store information about the round trip more easily.

Events are great for debugging, but some higher level abstraction
that takes into account all oddities is probably required.