### PR TITLE
http: implement easy handling of round trips

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -348,6 +348,23 @@ type HTTPRoundTripDoneEvent struct {
 	// Headers contains the response headers if error is nil.
 	Headers http.Header
 
+	// RedirectBody contains the redirect body that otherwise Go will
+	// ignore. We cap the maximum size to a reasonable value.
+	RedirectBody []byte
+
+	// RequestHeaders contain the original request headers. This is
+	// included here to make this event actionable without needing to
+	// join it with other events, as it's too important.
+	RequestHeaders http.Header
+
+	// RequestMethod is the original request method. This is here
+	// for the same reason of RequestHeaders.
+	RequestMethod string
+
+	// RequestURL is the original request URL. This is here
+	// for the same reason of RequestHeaders.
+	RequestURL string
+
 	// StatusCode contains the HTTP status code if error is nil.
 	StatusCode int64
 

--- a/x/logger/logger.go
+++ b/x/logger/logger.go
@@ -2,6 +2,7 @@
 package logger
 
 import (
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"strings"
@@ -170,21 +171,16 @@ func (h *Handler) OnMeasurement(m model.Measurement) {
 	}
 	if m.HTTPRoundTripDone != nil {
 		h.logger.WithFields(log.Fields{
-			"elapsed":       m.HTTPRoundTripDone.DurationSinceBeginning,
-			"error":         m.HTTPRoundTripDone.Error,
-			"statusCode":    m.HTTPRoundTripDone.StatusCode,
-			"transactionID": m.HTTPRoundTripDone.TransactionID,
+			"elapsed":         m.HTTPRoundTripDone.DurationSinceBeginning,
+			"error":           m.HTTPRoundTripDone.Error,
+			"headers":         m.HTTPRoundTripDone.Headers,
+			"redirect_body":   stringifyBody(m.HTTPRoundTripDone.RedirectBody),
+			"request_method":  m.HTTPRoundTripDone.RequestMethod,
+			"request_headers": m.HTTPRoundTripDone.RequestHeaders,
+			"request_url":     m.HTTPRoundTripDone.RequestURL,
+			"statusCode":      m.HTTPRoundTripDone.StatusCode,
+			"transactionID":   m.HTTPRoundTripDone.TransactionID,
 		}).Debug("http: round trip done")
-		for key, values := range m.HTTPRoundTripDone.Headers {
-			for _, value := range values {
-				h.logger.WithFields(log.Fields{
-					"elapsed":       m.HTTPRoundTripDone.DurationSinceBeginning,
-					"key":           key,
-					"transactionID": m.HTTPRoundTripDone.TransactionID,
-					"value":         value,
-				}).Debug("http: got header")
-			}
-		}
 	}
 
 	// HTTP response body
@@ -217,4 +213,8 @@ func (h *Handler) OnMeasurement(m model.Measurement) {
 
 func reformat(s string) string {
 	return strings.ReplaceAll(s, "\n", "\n\t")
+}
+
+func stringifyBody(d []byte) string {
+	return string(bytes.ReplaceAll(d, []byte("\n"), []byte(`\n`)))
 }


### PR DESCRIPTION
This diff implements easy handling of round trips by putting into
the same event all the information we may possibly need.

The only missing bit of information is the body of the final
request, which however can be read by other means.