### PR TITLE
nervousresolver: use cloudflare IP address

### DIFF
--- a/x/nervousresolver/nervousresolver.go
+++ b/x/nervousresolver/nervousresolver.go
@@ -134,7 +134,7 @@ func init() {
 	// this when integrating in probe-engine.
 	overhttps, err := internal.NewResolver(
 		time.Time{}, handlers.NoHandler,
-		"doh", "https://cloudflare-dns.com/dns-query",
+		"doh", "https://1.1.1.1/dns-query",
 	)
 	rtx.PanicOnError(err, "internal.NewResolver #2 failed")
 	Default = New(system, overhttps)


### PR DESCRIPTION
We should probably introduce a longer chain of fallbacks in the
nervous resolver, but, for now, using the IP address is good enough
because it can protect us against the whole DNS being down.

This happened to me in Italy, when "Vodafone rete sicura" had
several hours of outage and the default DNS was not working as
intended, while there was IP connectivity.

Reference issue: https://github.com/ooni/probe-engine/issues/88