### PR TITLE
internal: let the resolver emit resolve events

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ooni/netx/internal/dialer"
 	"github.com/ooni/netx/internal/httptransport"
 	"github.com/ooni/netx/internal/resolver"
+	"github.com/ooni/netx/internal/resolver/emitterresolver"
 	"github.com/ooni/netx/model"
 	"golang.org/x/net/http2"
 )
@@ -35,7 +36,7 @@ func NewDialer(
 	return &Dialer{
 		Beginning: beginning,
 		Handler:   handler,
-		Resolver:  new(net.Resolver),
+		Resolver:  resolver.NewResolverSystem(),
 		TLSConfig: new(tls.Config),
 	}
 }
@@ -146,7 +147,7 @@ func newResolverWrapper(
 	return &resolverWrapper{
 		beginning: beginning,
 		handler:   handler,
-		resolver:  resolver,
+		resolver:  emitterresolver.New(resolver),
 	}
 }
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ooni/netx/internal/dialer"
 	"github.com/ooni/netx/internal/httptransport"
 	"github.com/ooni/netx/internal/resolver"
-	"github.com/ooni/netx/internal/resolver/emitterresolver"
 	"github.com/ooni/netx/model"
 	"golang.org/x/net/http2"
 )
@@ -147,7 +146,7 @@ func newResolverWrapper(
 	return &resolverWrapper{
 		beginning: beginning,
 		handler:   handler,
-		resolver:  emitterresolver.New(resolver),
+		resolver:  resolver,
 	}
 }
 

--- a/internal/resolver/emitterresolver/emitterresolver.go
+++ b/internal/resolver/emitterresolver/emitterresolver.go
@@ -1,0 +1,75 @@
+// Package emitterresolver contains the resolver that emits events
+package emitterresolver
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/ooni/netx/internal/dialid"
+	"github.com/ooni/netx/internal/errwrapper"
+	"github.com/ooni/netx/internal/transactionid"
+	"github.com/ooni/netx/model"
+)
+
+// Resolver is the emitter resolver
+type Resolver struct {
+	resolver model.DNSResolver
+}
+
+// New creates a new emitter resolver
+func New(resolver model.DNSResolver) *Resolver {
+	return &Resolver{resolver: resolver}
+}
+
+// LookupAddr returns the name of the provided IP address
+func (r *Resolver) LookupAddr(ctx context.Context, addr string) ([]string, error) {
+	return r.resolver.LookupAddr(ctx, addr)
+}
+
+// LookupCNAME returns the canonical name of a host
+func (r *Resolver) LookupCNAME(ctx context.Context, host string) (string, error) {
+	return r.resolver.LookupCNAME(ctx, host)
+}
+
+// LookupHost returns the IP addresses of a host
+func (r *Resolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+	dialID := dialid.ContextDialID(ctx)
+	txID := transactionid.ContextTransactionID(ctx)
+	root := model.ContextMeasurementRootOrDefault(ctx)
+	root.Handler.OnMeasurement(model.Measurement{
+		ResolveStart: &model.ResolveStartEvent{
+			DialID:                 dialID,
+			DurationSinceBeginning: time.Now().Sub(root.Beginning),
+			Hostname:               hostname,
+			TransactionID:          txID,
+		},
+	})
+	addrs, err := r.resolver.LookupHost(ctx, hostname)
+	err = errwrapper.SafeErrWrapperBuilder{
+		DialID:        dialID,
+		Error:         err,
+		TransactionID: txID,
+	}.MaybeBuild()
+	root.Handler.OnMeasurement(model.Measurement{
+		ResolveDone: &model.ResolveDoneEvent{
+			Addresses:              addrs,
+			DialID:                 dialID,
+			DurationSinceBeginning: time.Now().Sub(root.Beginning),
+			Error:                  err,
+			Hostname:               hostname,
+			TransactionID:          txID,
+		},
+	})
+	return addrs, err
+}
+
+// LookupMX returns the MX records of a specific name
+func (r *Resolver) LookupMX(ctx context.Context, name string) ([]*net.MX, error) {
+	return r.resolver.LookupMX(ctx, name)
+}
+
+// LookupNS returns the NS records of a specific name
+func (r *Resolver) LookupNS(ctx context.Context, name string) ([]*net.NS, error) {
+	return r.resolver.LookupNS(ctx, name)
+}

--- a/internal/resolver/emitterresolver/emitterresolver_test.go
+++ b/internal/resolver/emitterresolver/emitterresolver_test.go
@@ -1,0 +1,97 @@
+package emitterresolver
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ooni/netx/model"
+)
+
+func TestLookupAddr(t *testing.T) {
+	client := New(new(net.Resolver))
+	addrs, err := client.LookupAddr(context.Background(), "130.192.91.211")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	for _, addr := range addrs {
+		t.Log(addr)
+	}
+}
+
+func TestLookupCNAME(t *testing.T) {
+	client := New(new(net.Resolver))
+	addrs, err := client.LookupCNAME(context.Background(), "www.ooni.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, addr := range addrs {
+		t.Log(addr)
+	}
+}
+
+type emitterchecker struct {
+	gotResolveStart bool
+	gotResolveDone  bool
+	mu              sync.Mutex
+}
+
+func (h *emitterchecker) OnMeasurement(m model.Measurement) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if m.ResolveStart != nil {
+		h.gotResolveStart = true
+	}
+	if m.ResolveDone != nil {
+		h.gotResolveDone = true
+	}
+}
+
+func TestLookupHost(t *testing.T) {
+	client := New(new(net.Resolver))
+	handler := new(emitterchecker)
+	ctx := model.WithMeasurementRoot(
+		context.Background(), &model.MeasurementRoot{
+			Beginning: time.Now(),
+			Handler:   handler,
+		})
+	addrs, err := client.LookupHost(ctx, "www.google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, addr := range addrs {
+		t.Log(addr)
+	}
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+	if handler.gotResolveStart == false {
+		t.Fatal("did not see resolve start event")
+	}
+	if handler.gotResolveDone == false {
+		t.Fatal("did not see resolve done event")
+	}
+}
+
+func TestLookupMX(t *testing.T) {
+	client := New(new(net.Resolver))
+	addrs, err := client.LookupMX(context.Background(), "ooni.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, addr := range addrs {
+		t.Log(addr)
+	}
+}
+
+func TestLookupNS(t *testing.T) {
+	client := New(new(net.Resolver))
+	addrs, err := client.LookupNS(context.Background(), "ooni.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, addr := range addrs {
+		t.Log(addr)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2,31 +2,46 @@
 package resolver
 
 import (
+	"net"
 	"net/http"
 
 	"github.com/ooni/netx/internal/resolver/dnstransport/dnsoverhttps"
 	"github.com/ooni/netx/internal/resolver/dnstransport/dnsovertcp"
 	"github.com/ooni/netx/internal/resolver/dnstransport/dnsoverudp"
+	"github.com/ooni/netx/internal/resolver/emitterresolver"
 	"github.com/ooni/netx/internal/resolver/ooniresolver"
 	"github.com/ooni/netx/model"
 )
 
+// NewResolverSystem creates a new Go/system resolver.
+func NewResolverSystem() *emitterresolver.Resolver {
+	return emitterresolver.New(new(net.Resolver))
+}
+
 // NewResolverUDP creates a new UDP resolver.
-func NewResolverUDP(dialer model.Dialer, address string) *ooniresolver.Resolver {
-	return ooniresolver.New(dnsoverudp.NewTransport(dialer, address))
+func NewResolverUDP(dialer model.Dialer, address string) *emitterresolver.Resolver {
+	return emitterresolver.New(
+		ooniresolver.New(dnsoverudp.NewTransport(dialer, address)),
+	)
 }
 
 // NewResolverTCP creates a new TCP resolver.
-func NewResolverTCP(dialer model.Dialer, address string) *ooniresolver.Resolver {
-	return ooniresolver.New(dnsovertcp.NewTransportTCP(dialer, address))
+func NewResolverTCP(dialer model.Dialer, address string) *emitterresolver.Resolver {
+	return emitterresolver.New(
+		ooniresolver.New(dnsovertcp.NewTransportTCP(dialer, address)),
+	)
 }
 
 // NewResolverTLS creates a new DoT resolver.
-func NewResolverTLS(dialer model.TLSDialer, address string) *ooniresolver.Resolver {
-	return ooniresolver.New(dnsovertcp.NewTransportTLS(dialer, address))
+func NewResolverTLS(dialer model.TLSDialer, address string) *emitterresolver.Resolver {
+	return emitterresolver.New(
+		ooniresolver.New(dnsovertcp.NewTransportTLS(dialer, address)),
+	)
 }
 
 // NewResolverHTTPS creates a new DoH resolver.
-func NewResolverHTTPS(client *http.Client, address string) *ooniresolver.Resolver {
-	return ooniresolver.New(dnsoverhttps.NewTransport(client, address))
+func NewResolverHTTPS(client *http.Client, address string) *emitterresolver.Resolver {
+	return emitterresolver.New(
+		ooniresolver.New(dnsoverhttps.NewTransport(client, address)),
+	)
 }


### PR DESCRIPTION
This fixes a bug where a standalone Resolver would not emit
the final result of its resolve, because there is no dial
attached to the resolve itself. Also, from a logic standpoint,
it seems anyway better to emit such event there.