### PR TITLE
resolve: let transports identify themselves

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ooni/netx/internal/dialer"
 	"github.com/ooni/netx/internal/httptransport"
 	"github.com/ooni/netx/internal/resolver"
+	"github.com/ooni/netx/internal/resolver/emitterresolver"
 	"github.com/ooni/netx/model"
 	"golang.org/x/net/http2"
 )
@@ -146,7 +147,7 @@ func newResolverWrapper(
 	return &resolverWrapper{
 		beginning: beginning,
 		handler:   handler,
-		resolver:  resolver,
+		resolver:  emitterresolver.New(resolver),
 	}
 }
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ooni/netx/internal/dialer"
 	"github.com/ooni/netx/internal/httptransport"
 	"github.com/ooni/netx/internal/resolver"
-	"github.com/ooni/netx/internal/resolver/emitterresolver"
 	"github.com/ooni/netx/model"
 	"golang.org/x/net/http2"
 )
@@ -147,7 +146,7 @@ func newResolverWrapper(
 	return &resolverWrapper{
 		beginning: beginning,
 		handler:   handler,
-		resolver:  emitterresolver.New(resolver),
+		resolver:  resolver,
 	}
 }
 

--- a/internal/resolver/ooniresolver/ooniresolver.go
+++ b/internal/resolver/ooniresolver/ooniresolver.go
@@ -26,6 +26,11 @@ func New(t model.DNSRoundTripper) *Resolver {
 	return &Resolver{transport: t}
 }
 
+// Transport returns the transport being used.
+func (c *Resolver) Transport() model.DNSRoundTripper {
+	return c.transport
+}
+
 var errNotImpl = errors.New("Not implemented")
 
 // LookupAddr returns the name of the provided IP address

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -10,12 +10,13 @@ import (
 	"github.com/ooni/netx/internal/resolver/dnstransport/dnsoverudp"
 	"github.com/ooni/netx/internal/resolver/emitterresolver"
 	"github.com/ooni/netx/internal/resolver/ooniresolver"
+	"github.com/ooni/netx/internal/resolver/systemresolver"
 	"github.com/ooni/netx/model"
 )
 
 // NewResolverSystem creates a new Go/system resolver.
 func NewResolverSystem() *emitterresolver.Resolver {
-	return emitterresolver.New(new(net.Resolver))
+	return emitterresolver.New(systemresolver.New(new(net.Resolver)))
 }
 
 // NewResolverUDP creates a new UDP resolver.

--- a/internal/resolver/systemresolver/systemresolver.go
+++ b/internal/resolver/systemresolver/systemresolver.go
@@ -1,0 +1,66 @@
+// Package systemresolver contains the system resolver
+package systemresolver
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/ooni/netx/model"
+)
+
+// Resolver is the system resolver
+type Resolver struct {
+	resolver model.DNSResolver
+}
+
+// New creates a new system resolver
+func New(resolver model.DNSResolver) *Resolver {
+	return &Resolver{resolver: resolver}
+}
+
+// LookupAddr returns the name of the provided IP address
+func (r *Resolver) LookupAddr(ctx context.Context, addr string) ([]string, error) {
+	return r.resolver.LookupAddr(ctx, addr)
+}
+
+// LookupCNAME returns the canonical name of a host
+func (r *Resolver) LookupCNAME(ctx context.Context, host string) (string, error) {
+	return r.resolver.LookupCNAME(ctx, host)
+}
+
+type fakeTransport struct{}
+
+func (*fakeTransport) RoundTrip(
+	ctx context.Context, query []byte,
+) (reply []byte, err error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*fakeTransport) Network() string {
+	return "system"
+}
+
+func (*fakeTransport) Address() string {
+	return ""
+}
+
+// Transport returns the transport being used
+func (r *Resolver) Transport() model.DNSRoundTripper {
+	return &fakeTransport{}
+}
+
+// LookupHost returns the IP addresses of a host
+func (r *Resolver) LookupHost(ctx context.Context, hostname string) ([]string, error) {
+	return r.resolver.LookupHost(ctx, hostname)
+}
+
+// LookupMX returns the MX records of a specific name
+func (r *Resolver) LookupMX(ctx context.Context, name string) ([]*net.MX, error) {
+	return r.resolver.LookupMX(ctx, name)
+}
+
+// LookupNS returns the NS records of a specific name
+func (r *Resolver) LookupNS(ctx context.Context, name string) ([]*net.NS, error) {
+	return r.resolver.LookupNS(ctx, name)
+}

--- a/internal/resolver/systemresolver/systemresolver_test.go
+++ b/internal/resolver/systemresolver/systemresolver_test.go
@@ -1,0 +1,95 @@
+package systemresolver
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/ooni/netx/model"
+)
+
+type queryableTransport interface {
+	Network() string
+	Address() string
+}
+
+type queryableResolver interface {
+	Transport() model.DNSRoundTripper
+}
+
+func TestCanQuery(t *testing.T) {
+	var client model.DNSResolver = New(new(net.Resolver))
+	transport := client.(queryableResolver).Transport()
+	reply, err := transport.RoundTrip(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	if err.Error() != "not implemented" {
+		t.Fatal("not the error we expected")
+	}
+	if reply != nil {
+		t.Fatal("expected nil reply here")
+	}
+	queryableTransport := transport.(queryableTransport)
+	if queryableTransport.Address() != "" {
+		t.Fatal("invalid address")
+	}
+	if queryableTransport.Network() != "system" {
+		t.Fatal("invalid network")
+	}
+}
+
+func TestLookupAddr(t *testing.T) {
+	client := New(new(net.Resolver))
+	addrs, err := client.LookupAddr(context.Background(), "130.192.91.211")
+	if err == nil {
+		t.Fatal("expected an error here")
+	}
+	for _, addr := range addrs {
+		t.Log(addr)
+	}
+}
+
+func TestLookupCNAME(t *testing.T) {
+	client := New(new(net.Resolver))
+	addrs, err := client.LookupCNAME(context.Background(), "www.ooni.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, addr := range addrs {
+		t.Log(addr)
+	}
+}
+
+func TestLookupHost(t *testing.T) {
+	client := New(new(net.Resolver))
+	addrs, err := client.LookupHost(context.Background(), "www.google.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, addr := range addrs {
+		t.Log(addr)
+	}
+}
+
+func TestLookupMX(t *testing.T) {
+	client := New(new(net.Resolver))
+	addrs, err := client.LookupMX(context.Background(), "ooni.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, addr := range addrs {
+		t.Log(addr)
+	}
+}
+
+func TestLookupNS(t *testing.T) {
+	client := New(new(net.Resolver))
+	addrs, err := client.LookupNS(context.Background(), "ooni.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, addr := range addrs {
+		t.Log(addr)
+	}
+}

--- a/model/model.go
+++ b/model/model.go
@@ -448,6 +448,14 @@ type ResolveStartEvent struct {
 	// TransactionID is the ID of the HTTP transaction that caused the
 	// current dial to run, or zero if there's no such transaction.
 	TransactionID int64 `json:",omitempty"`
+
+	// TransportNetwork is the network used by the DNS transport, which
+	// can be only of "doh", "dot", "tcp", "udp", or empty.
+	TransportNetwork string
+
+	// TransportAddress is the address used by the DNS transport, which
+	// is of course relative to the TransportNetwork.
+	TransportAddress string
 }
 
 // ResolveDoneEvent is emitted when we know the IP addresses of a
@@ -473,6 +481,14 @@ type ResolveDoneEvent struct {
 	// TransactionID is the ID of the HTTP transaction that caused the
 	// current dial to run, or zero if there's no such transaction.
 	TransactionID int64 `json:",omitempty"`
+
+	// TransportNetwork is the network used by the DNS transport, which
+	// can be only of "doh", "dot", "tcp", "udp", or empty.
+	TransportNetwork string
+
+	// TransportAddress is the address used by the DNS transport, which
+	// is of course relative to the TransportNetwork.
+	TransportAddress string
 }
 
 // X509Certificate is an x.509 certificate.


### PR DESCRIPTION
So we know what DNS transport was used for which resolve.