### PR TITLE
fix(internal.go): make sure system resolver emits events

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -187,9 +187,8 @@ func NewResolver(
 	// Implementation note: system need to be dealt with
 	// separately because it doesn't have any transport.
 	if network == "system" {
-		return newResolverWrapper(beginning, handler, &net.Resolver{
-			PreferGo: false,
-		}), nil
+		return newResolverWrapper(
+			beginning, handler, resolver.NewResolverSystem()), nil
 	}
 	if network == "doh" {
 		return newResolverWrapper(beginning, handler, resolver.NewResolverHTTPS(


### PR DESCRIPTION
We were creating a system resolver that was not correctly wrapped
using the emittingresolver, hence we didn't see events.