### PR TITLE
http: change body reading strategy

### DIFF
--- a/internal/httptransport/bodytracer/bodytracer.go
+++ b/internal/httptransport/bodytracer/bodytracer.go
@@ -1,5 +1,6 @@
-// Package bodyreader contains the top HTTP body reader.
-package bodyreader
+// Package bodytracer contains the HTTP body tracer. The purpose
+// of tracing is to emit events while we read response bodies.
+package bodytracer
 
 import (
 	"io"

--- a/internal/httptransport/bodytracer/bodytracer_test.go
+++ b/internal/httptransport/bodytracer/bodytracer_test.go
@@ -1,4 +1,4 @@
-package bodyreader
+package bodytracer
 
 import (
 	"io/ioutil"

--- a/internal/httptransport/httptransport.go
+++ b/internal/httptransport/httptransport.go
@@ -5,7 +5,7 @@ package httptransport
 import (
 	"net/http"
 
-	"github.com/ooni/netx/internal/httptransport/bodyreader"
+	"github.com/ooni/netx/internal/httptransport/bodytracer"
 	"github.com/ooni/netx/internal/httptransport/tracetripper"
 	"github.com/ooni/netx/internal/httptransport/transactioner"
 )
@@ -19,7 +19,7 @@ type Transport struct {
 // New creates a new Transport.
 func New(roundTripper http.RoundTripper) *Transport {
 	return &Transport{
-		roundTripper: transactioner.New(bodyreader.New(
+		roundTripper: transactioner.New(bodytracer.New(
 			tracetripper.New(roundTripper))),
 	}
 }

--- a/model/model.go
+++ b/model/model.go
@@ -348,9 +348,11 @@ type HTTPRoundTripDoneEvent struct {
 	// Headers contains the response headers if error is nil.
 	Headers http.Header
 
-	// RedirectBody contains the redirect body that otherwise Go will
-	// ignore. We cap the maximum size to a reasonable value.
-	RedirectBody []byte
+	// RequestBodySnap contains a snap of the request body. We'll
+	// not read more than SnapSize bytes of the body. Because typically
+	// you control the request bodies that you send, perhaps think
+	// about saving them using other means.
+	RequestBodySnap []byte
 
 	// RequestHeaders contain the original request headers. This is
 	// included here to make this event actionable without needing to
@@ -364,6 +366,15 @@ type HTTPRoundTripDoneEvent struct {
 	// RequestURL is the original request URL. This is here
 	// for the same reason of RequestHeaders.
 	RequestURL string
+
+	// BodySnap is like RequestBodySnap but for the response. You
+	// can still save the whole body by just reading it, if this
+	// is something that you need to do. We're using the snaps here
+	// mainly to log small stuff like DoH and redirects.
+	BodySnap []byte
+
+	// SnapSize is the size of the bodies snapshot
+	SnapSize int64
 
 	// StatusCode contains the HTTP status code if error is nil.
 	StatusCode int64

--- a/x/logger/logger.go
+++ b/x/logger/logger.go
@@ -175,15 +175,18 @@ func (h *Handler) OnMeasurement(m model.Measurement) {
 	}
 	if m.HTTPRoundTripDone != nil {
 		h.logger.WithFields(log.Fields{
-			"elapsed":         m.HTTPRoundTripDone.DurationSinceBeginning,
-			"error":           m.HTTPRoundTripDone.Error,
-			"headers":         m.HTTPRoundTripDone.Headers,
-			"redirect_body":   stringifyBody(m.HTTPRoundTripDone.RedirectBody),
-			"request_method":  m.HTTPRoundTripDone.RequestMethod,
-			"request_headers": m.HTTPRoundTripDone.RequestHeaders,
-			"request_url":     m.HTTPRoundTripDone.RequestURL,
-			"statusCode":      m.HTTPRoundTripDone.StatusCode,
-			"transactionID":   m.HTTPRoundTripDone.TransactionID,
+			"elapsed":                 m.HTTPRoundTripDone.DurationSinceBeginning,
+			"error":                   m.HTTPRoundTripDone.Error,
+			"headers":                 m.HTTPRoundTripDone.Headers,
+			"request_body":            stringifyBody(m.HTTPRoundTripDone.RequestBody),
+			"request_body_why_saved":  m.HTTPRoundTripDone.RequestBodyWhySaved,
+			"request_method":          m.HTTPRoundTripDone.RequestMethod,
+			"request_headers":         m.HTTPRoundTripDone.RequestHeaders,
+			"request_url":             m.HTTPRoundTripDone.RequestURL,
+			"response_body":           stringifyBody(m.HTTPRoundTripDone.ResponseBody),
+			"response_body_why_saved": m.HTTPRoundTripDone.ResponseBodyWhySaved,
+			"statusCode":              m.HTTPRoundTripDone.StatusCode,
+			"transactionID":           m.HTTPRoundTripDone.TransactionID,
 		}).Debug("http: round trip done")
 	}
 

--- a/x/logger/logger.go
+++ b/x/logger/logger.go
@@ -175,18 +175,17 @@ func (h *Handler) OnMeasurement(m model.Measurement) {
 	}
 	if m.HTTPRoundTripDone != nil {
 		h.logger.WithFields(log.Fields{
-			"elapsed":                 m.HTTPRoundTripDone.DurationSinceBeginning,
-			"error":                   m.HTTPRoundTripDone.Error,
-			"headers":                 m.HTTPRoundTripDone.Headers,
-			"request_body":            stringifyBody(m.HTTPRoundTripDone.RequestBody),
-			"request_body_why_saved":  m.HTTPRoundTripDone.RequestBodyWhySaved,
-			"request_method":          m.HTTPRoundTripDone.RequestMethod,
-			"request_headers":         m.HTTPRoundTripDone.RequestHeaders,
-			"request_url":             m.HTTPRoundTripDone.RequestURL,
-			"response_body":           stringifyBody(m.HTTPRoundTripDone.ResponseBody),
-			"response_body_why_saved": m.HTTPRoundTripDone.ResponseBodyWhySaved,
-			"statusCode":              m.HTTPRoundTripDone.StatusCode,
-			"transactionID":           m.HTTPRoundTripDone.TransactionID,
+			"elapsed":         m.HTTPRoundTripDone.DurationSinceBeginning,
+			"error":           m.HTTPRoundTripDone.Error,
+			"headers":         m.HTTPRoundTripDone.Headers,
+			"request_body":    stringifyBody(m.HTTPRoundTripDone.RequestBodySnap),
+			"request_method":  m.HTTPRoundTripDone.RequestMethod,
+			"request_headers": m.HTTPRoundTripDone.RequestHeaders,
+			"request_url":     m.HTTPRoundTripDone.RequestURL,
+			"response_body":   stringifyBody(m.HTTPRoundTripDone.BodySnap),
+			"snap_size":       m.HTTPRoundTripDone.SnapSize,
+			"statusCode":      m.HTTPRoundTripDone.StatusCode,
+			"transactionID":   m.HTTPRoundTripDone.TransactionID,
 		}).Debug("http: round trip done")
 	}
 

--- a/x/porcelain/porcelain.go
+++ b/x/porcelain/porcelain.go
@@ -2,6 +2,8 @@
 //
 // This is the main package used by ooni/probe-engine. The objective
 // of this package is to make things simple in probe-engine.
+//
+// Also, this is currently experimental. So, no API promises here.
 package porcelain
 
 import (
@@ -48,6 +50,7 @@ type HTTPRequest struct {
 	Method  string
 	URL     string
 	Headers http.Header
+	Body    string
 }
 
 // HTTPResponse contains the response summary. This is structured so
@@ -127,11 +130,12 @@ func (h *getHandler) OnMeasurement(m model.Measurement) {
 				Method:  rtinfo.RequestMethod,
 				URL:     rtinfo.RequestURL,
 				Headers: rtinfo.RequestHeaders,
+				Body:    string(rtinfo.RequestBodySnap),
 			},
 			Response: HTTPResponse{
 				StatusCode: rtinfo.StatusCode,
 				Headers:    rtinfo.Headers,
-				Body:       string(rtinfo.RedirectBody),
+				Body:       string(rtinfo.BodySnap),
 			},
 			TransactionID: rtinfo.TransactionID,
 		})


### PR DESCRIPTION
Always read snapshots of all bodies. Limit snapshot to 1<<17
that is good enough because:

1. for requests, we can always save them since we issue them but
it may be useful to save small requests

2. for responses, we can always save them except redirects and
DoH, and in both cases we are talking about small bodies

Fixes the output emitted by a DoH query.

We can now probably further simplify porcelain.go in a followup PR.