### PR TITLE
Fix several DNS issues when testing with jafar

### DIFF
--- a/internal/errwrapper/errwrapper.go
+++ b/internal/errwrapper/errwrapper.go
@@ -90,6 +90,9 @@ func toFailureString(err error) string {
 	if strings.HasSuffix(s, "i/o timeout") {
 		return "generic_timeout_error"
 	}
+	if strings.HasSuffix(s, "TLS handshake timeout") {
+		return "generic_timeout_error"
+	}
 	if strings.HasSuffix(s, "no such host") {
 		// This is dns_lookup_error in MK but such error is used as a
 		// generic "hey, the lookup failed" error. Instead, this error

--- a/internal/errwrapper/errwrapper_test.go
+++ b/internal/errwrapper/errwrapper_test.go
@@ -107,6 +107,12 @@ func TestToFailureString(t *testing.T) {
 			t.Fatal("unexpected results")
 		}
 	})
+	t.Run("for TLS handshake timeout error", func(t *testing.T) {
+		err := errors.New("net/http: TLS handshake timeout")
+		if toFailureString(err) != "generic_timeout_error" {
+			t.Fatal("unexpected results")
+		}
+	})
 	t.Run("for no such host", func(t *testing.T) {
 		if toFailureString(&net.DNSError{
 			Err: "no such host",

--- a/internal/resolver/ooniresolver/ooniresolver_test.go
+++ b/internal/resolver/ooniresolver/ooniresolver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -111,6 +112,9 @@ func TestLookupNonexistent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error here")
 	}
+	if !strings.HasSuffix(err.Error(), "no such host") {
+		t.Fatal("not the error we expected")
+	}
 	if addrs != nil {
 		t.Fatal("expected nil addr here")
 	}
@@ -212,5 +216,21 @@ func TestLookupHostResultAAAAError(t *testing.T) {
 	}
 	if addrs != nil {
 		t.Fatal("expected nil addrs")
+	}
+}
+
+func TestUnitMapError(t *testing.T) {
+	if mapError(dns.RcodeSuccess) != nil {
+		t.Fatal("unexpected return value")
+	}
+	if err := mapError(dns.RcodeNameError); !strings.HasSuffix(
+		err.Error(), "no such host",
+	) {
+		t.Fatal("unexpected return value")
+	}
+	if err := mapError(dns.RcodeBadName); !strings.HasSuffix(
+		err.Error(), "query failed",
+	) {
+		t.Fatal("unexpected return value")
 	}
 }

--- a/model/model.go
+++ b/model/model.go
@@ -689,7 +689,7 @@ type XResults struct {
 type XSNIBlockingFollowup struct {
 	Connects      []*ConnectEvent
 	HTTPRequests  []*HTTPRoundTripDoneEvent
-	Queries       []*ResolveDoneEvent
+	Resolves      []*ResolveDoneEvent
 	TLSHandshakes []*TLSHandshakeDoneEvent
 }
 

--- a/x/porcelain/porcelain.go
+++ b/x/porcelain/porcelain.go
@@ -46,7 +46,7 @@ func (h *channelHandler) OnMeasurement(m model.Measurement) {
 type Results struct {
 	Connects      []*model.ConnectEvent
 	HTTPRequests  []*model.HTTPRoundTripDoneEvent
-	Queries       []*model.ResolveDoneEvent
+	Resolves      []*model.ResolveDoneEvent
 	Scoreboard    *scoreboard.Board
 	TLSHandshakes []*model.TLSHandshakeDoneEvent
 }
@@ -59,7 +59,7 @@ func (r *Results) onMeasurement(m model.Measurement) {
 		r.HTTPRequests = append(r.HTTPRequests, m.HTTPRoundTripDone)
 	}
 	if m.ResolveDone != nil {
-		r.Queries = append(r.Queries, m.ResolveDone)
+		r.Resolves = append(r.Resolves, m.ResolveDone)
 	}
 	if m.TLSHandshakeDone != nil {
 		r.TLSHandshakes = append(r.TLSHandshakes, m.TLSHandshakeDone)
@@ -369,7 +369,7 @@ func sniBlockingFollowup(
 		out = &model.XSNIBlockingFollowup{
 			Connects:      measurements.TestKeys.Connects,
 			HTTPRequests:  measurements.TestKeys.HTTPRequests,
-			Queries:       measurements.TestKeys.Queries,
+			Resolves:      measurements.TestKeys.Resolves,
 			TLSHandshakes: measurements.TestKeys.TLSHandshakes,
 		}
 	}

--- a/x/porcelain/porcelain_test.go
+++ b/x/porcelain/porcelain_test.go
@@ -259,7 +259,7 @@ func TestMaybeRunTLSChecks(t *testing.T) {
 	if out.HTTPRequests != nil {
 		t.Fatal("http requests?!")
 	}
-	if out.Queries == nil {
+	if out.Resolves == nil {
 		t.Fatal("no queries?!")
 	}
 	if out.TLSHandshakes == nil {


### PR DESCRIPTION
* errwrapper: map the TLS handshake timeout error

* ooniresolver: correctly recognize and handle NXDOMAIN in ooniresolver

* XSNIBlockingFollowup: better naming for resolve results, which
are clearly more coarse grained than just "queries"

Xref: https://github.com/ooni/probe-engine/issues/87