### PR TITLE
internal: use global doh client with NoHandler

### DIFF
--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -341,3 +341,21 @@ func TestLookupNSWrapper(t *testing.T) {
 		t.Fatal("unexpected result")
 	}
 }
+
+func TestUnitNewClientForDoH(t *testing.T) {
+	first := newHTTPClientForDoH(
+		time.Now(), handlers.NoHandler,
+	)
+	second := newHTTPClientForDoH(
+		time.Now(), handlers.NoHandler,
+	)
+	if first != second {
+		t.Fatal("expected to see same client here")
+	}
+	third := newHTTPClientForDoH(
+		time.Now(), handlers.StdoutHandler,
+	)
+	if first == third {
+		t.Fatal("expected to see different client here")
+	}
+}

--- a/x/porcelain/porcelain.go
+++ b/x/porcelain/porcelain.go
@@ -166,7 +166,6 @@ func DNSLookup(
 	ctx context.Context, config DNSLookupConfig,
 ) (*DNSLookupResults, error) {
 	channel := make(chan model.Measurement)
-	// TODO(bassosimone): tell DoH to use specific CA bundle?
 	root := &model.MeasurementRoot{
 		Beginning: time.Now(),
 		Handler: &channelHandler{
@@ -193,7 +192,6 @@ func DNSLookup(
 		results.Addresses, results.Error = addrs, err
 	})
 	results.TestKeys.Scoreboard = &root.X.Scoreboard
-	// TODO(bassosimone): tell DoH to close idle connections?
 	return results, nil
 }
 
@@ -254,7 +252,6 @@ func HTTPDo(
 	)
 	results.TestKeys.collect(channel, config.Handler, func() {
 		defer client.HTTPClient.CloseIdleConnections()
-		// TODO(bassosimone): tell DoH to close idle connections?
 		resp, err := client.HTTPClient.Do(req)
 		if err != nil {
 			mu.Lock()


### PR DESCRIPTION
As explained in the code, this allows us to avoid worrying about
closing the connections that an interim HTTP client may have
opened, saving lots of API complexity. Because setting NoHandler
as the handler is really the common case, this is a good enough
not-so-complex solution to avoid the technical debt caused by
failing to close the open connections of an *http.Client.