### PR TITLE
internal: no keepalive if doh with handler

### DIFF
--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -22,7 +22,12 @@ type Transport struct {
 func NewTransport(beginning time.Time, handler model.Handler) *Transport {
 	t := new(Transport)
 	t.dialer = internal.NewDialer(beginning, handler)
-	t.transport = internal.NewHTTPTransport(beginning, handler, t.dialer)
+	t.transport = internal.NewHTTPTransport(
+		beginning,
+		handler,
+		t.dialer,
+		false, // DisableKeepAlives
+	)
 	return t
 }
 

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -251,6 +251,7 @@ func TestIntegration(t *testing.T) {
 		Transport: NewHTTPTransport(
 			time.Now(), handlers.NoHandler,
 			NewDialer(time.Now(), handlers.NoHandler),
+			false,
 		),
 	}
 	resp, err := client.Get("https://www.google.com")
@@ -284,6 +285,7 @@ func TestIntegrationFailure(t *testing.T) {
 		Transport: NewHTTPTransport(
 			time.Now(), handlers.NoHandler,
 			NewDialer(time.Now(), handlers.NoHandler),
+			false,
 		),
 	}
 	// This fails the request because we attempt to speak cleartext HTTP with
@@ -342,7 +344,7 @@ func TestLookupNSWrapper(t *testing.T) {
 	}
 }
 
-func TestUnitNewClientForDoH(t *testing.T) {
+func TestUnitNewHTTPClientForDoH(t *testing.T) {
 	first := newHTTPClientForDoH(
 		time.Now(), handlers.NoHandler,
 	)


### PR DESCRIPTION
Complement the previous path by forcing no keepalives if the
user requests doh with a handler.

This reduces the technical debt entailed by DoH to zero.