### PR TITLE
Make sure clients for measurements don't use proxy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 | Author       | Simone Basso |
 |--------------|--------------|
-| Last-Updated | 2019-10-30   |
+| Last-Updated | 2019-11-01   |
 | Status       | approved     |
 
 ## Introduction
@@ -220,18 +220,18 @@ func (c *Client) SetResolver(r model.DNSResolver)
 
 Also `SetResolver` is described below.
 
-```Go
-func (c *Client) SetProxyFunc(f func(*Request) (*url.URL, error) error
-```
-
-The `SetProxyFunc` will allow us to configure
-a specific proxy. This is useful to have precise
-measurements of requests over, say, Psiphon.
-
 Lastly, one will construct an `http.Client` using:
 
 ```Go
 func NewClient(handler model.Handler) *Client
+```
+
+If you want a new client that will not honour the
+`HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment
+variables and that really uses no proxy, use:
+
+```Go
+func NewClientWithoutProxy(handler model.Handler) *Client
 ```
 
 The `handler` shall point to a structure implementing the

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -252,6 +252,7 @@ func TestIntegration(t *testing.T) {
 			time.Now(), handlers.NoHandler,
 			NewDialer(time.Now(), handlers.NoHandler),
 			false,
+			http.ProxyFromEnvironment,
 		),
 	}
 	resp, err := client.Get("https://www.google.com")
@@ -286,6 +287,7 @@ func TestIntegrationFailure(t *testing.T) {
 			time.Now(), handlers.NoHandler,
 			NewDialer(time.Now(), handlers.NoHandler),
 			false,
+			http.ProxyFromEnvironment,
 		),
 	}
 	// This fails the request because we attempt to speak cleartext HTTP with

--- a/x/porcelain/porcelain.go
+++ b/x/porcelain/porcelain.go
@@ -229,7 +229,7 @@ func HTTPDo(
 		},
 	}
 	ctx := model.WithMeasurementRoot(origCtx, root)
-	client := httpx.NewClient(handlers.NoHandler)
+	client := httpx.NewClientWithoutProxy(handlers.NoHandler)
 	resolver, err := configureDNS(
 		time.Now().UnixNano(),
 		config.DNSServerNetwork,


### PR DESCRIPTION
Related to #9 but implemented differently.