### PR TITLE
DESIGN.md: simplify and reorganize after recent changes

### DIFF
--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/internal"
 	"github.com/ooni/netx/model"
 )
@@ -32,6 +33,14 @@ func newTransport(
 		proxyFunc,
 	)
 	return t
+}
+
+// NewTransportWithProxyFunc creates a transport without any
+// handler attached using the specified proxy func.
+func NewTransportWithProxyFunc(
+	proxyFunc func(*http.Request) (*url.URL, error),
+) *Transport {
+	return newTransport(time.Now(), handlers.NoHandler, proxyFunc)
 }
 
 // NewTransport creates a new Transport. The beginning argument is

--- a/httpx/httpx_test.go
+++ b/httpx/httpx_test.go
@@ -90,6 +90,12 @@ func TestNewTransportHonoursProxy(t *testing.T) {
 	proxyTestMain(t, client, 451)
 }
 
+func TestNewTransportWithoutAnyProxy(t *testing.T) {
+	transport := httpx.NewTransportWithProxyFunc(nil)
+	client := &http.Client{Transport: transport}
+	proxyTestMain(t, client, 200)
+}
+
 func proxyTestMain(t *testing.T, client *http.Client, expect int) {
 	req, err := http.NewRequest("GET", "http://www.google.com", nil)
 	if err != nil {

--- a/netx.go
+++ b/netx.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/internal"
 	"github.com/ooni/netx/model"
 )
@@ -23,6 +24,13 @@ type Dialer struct {
 func NewDialer(handler model.Handler) *Dialer {
 	return &Dialer{
 		dialer: internal.NewDialer(time.Now(), handler),
+	}
+}
+
+// NewDialerWithoutHandler returns a new Dialer instance.
+func NewDialerWithoutHandler() *Dialer {
+	return &Dialer{
+		dialer: internal.NewDialer(time.Now(), handlers.NoHandler),
 	}
 }
 
@@ -108,6 +116,11 @@ func (d *Dialer) NewResolver(network, address string) (model.DNSResolver, error)
 // NewResolver is a standalone Dialer.NewResolver
 func NewResolver(handler model.Handler, network, address string) (model.DNSResolver, error) {
 	return internal.NewResolver(time.Now(), handler, network, address)
+}
+
+// NewResolverWithoutHandler creates a standalone Resolver
+func NewResolverWithoutHandler(network, address string) (model.DNSResolver, error) {
+	return internal.NewResolver(time.Now(), handlers.NoHandler, network, address)
 }
 
 // SetCABundle configures the dialer to use a specific CA bundle. This

--- a/netx_test.go
+++ b/netx_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIntegrationDialer(t *testing.T) {
-	dialer := netx.NewDialer(handlers.NoHandler)
+	dialer := netx.NewDialerWithoutHandler()
 	err := dialer.ConfigureDNS("udp", "1.1.1.1:53")
 	if err != nil {
 		t.Fatal(err)
@@ -76,6 +76,20 @@ func TestIntegrationResolver(t *testing.T) {
 
 func TestIntegrationStandaloneResolver(t *testing.T) {
 	resolver, err := netx.NewResolver(handlers.NoHandler, "tcp", "1.1.1.1:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addrs, err := resolver.LookupHost(context.Background(), "ooni.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) < 1 {
+		t.Fatal("No addresses returned")
+	}
+}
+
+func TestIntegrationStandaloneResolverWithoutHandler(t *testing.T) {
+	resolver, err := netx.NewResolverWithoutHandler("tcp", "1.1.1.1:53")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
No real API change. What changes is the way in which I think
about next, so updated the document to reflect that.

While there, define a bunch of more tidy APIs where we can
avoid passing in handlers.NoHandler explicitly.

Also, the real replacement is the transport and not the client
which is just syntactic sugar around it. Make it clear.