### PR TITLE
refactor: rename model modelx

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 | Author       | Simone Basso |
 |--------------|--------------|
-| Last-Updated | 2019-11-01   |
+| Last-Updated | 2019-11-02   |
 | Status       | approved     |
 
 ## Introduction
@@ -99,7 +99,7 @@ This library MUST wrap `error` such that:
 
 2. we can map them to major operations.
 
-The `github.com/ooni/netx/model` MUST contain a wrapper for
+The `github.com/ooni/netx/modelx` MUST contain a wrapper for
 Go `error` named `ErrWrapper` that is at least like:
 
 ```Go
@@ -142,7 +142,7 @@ that we can cast back to `ErrWrapper` during the analysis
 phase, using Go 1.13 `errors` library as follows:
 
 ```Go
-var wrapper *model.ErrWrapper
+var wrapper *modelx.ErrWrapper
 if errors.As(err, &wrapper) == true {
     // Do something with the error
 }
@@ -162,7 +162,7 @@ interfaces in the Go standard library:
 4. `net.Resolver`
 
 Accordingly, we'll define the following interfaces in
-the `github.com/ooni/next/model` package:
+the `github.com/ooni/next/modelx` package:
 
 ```Go
 type DNSResolver interface {
@@ -206,7 +206,7 @@ another resolve that performs the real resolution.
 
 ## Dispatching events
 
-The `github.com/ooni/netx/model` package will define
+The `github.com/ooni/netx/modelx` package will define
 an handler for low level events as:
 
 ```Go
@@ -261,7 +261,7 @@ r, err := netx.NewResolverWithoutHandler(DNSNetwork, DNSAddress)
 if err != nil {
     log.Fatal("cannot configure specifc resolver")
 }
-var resolver model.DNSResolver = r
+var resolver modelx.DNSResolver = r
 // now use resolver ...
 ```
 
@@ -299,7 +299,7 @@ The package will also contain this function:
 
 ```Go
 func ChainResolvers(
-    primary, secondary model.DNSResolver) model.DNSResolver
+    primary, secondary modelx.DNSResolver) modelx.DNSResolver
 ```
 
 where you can create a new resolver where `secondary` will be
@@ -316,7 +316,7 @@ d := netx.NewDialerWithoutHandler()
 d.SetResolver(resolver)
 d.ForceSpecificSNI("www.kernel.org")
 d.SetCABundle("/etc/ssl/cert.pem")
-var dialer model.Dialer = d
+var dialer modelx.Dialer = d
 // now use dialer
 ```
 
@@ -348,7 +348,7 @@ methods, but this fully describes the design.
 
 ## Structure of events
 
-The `github.com/ooni/netx/model` will contain the
+The `github.com/ooni/netx/modelx` will contain the
 definition of low-level events. We are interested in
 knowing the following:
 
@@ -366,7 +366,7 @@ as part of using DoT and DoH.
 
 We will represent time as a `time.Duration` since the
 beginning configured either in the context or when
-constructing an object. The `model` package will also
+constructing an object. The `modelx` package will also
 define the `Measurement` event as follows:
 
 ```Go

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ are also able to intercept and save DNS messages, as well as any
 other interaction with the remote server (e.g., the result of the
 TLS handshake for DoT and DoH).
 
-### github.com/ooni/netx/model
+### github.com/ooni/netx/modelx
 
-[![GoDoc](https://godoc.org/github.com/ooni/netx/model?status.svg)](
-https://godoc.org/github.com/ooni/netx/model)
+[![GoDoc](https://godoc.org/github.com/ooni/netx/modelx?status.svg)](
+https://godoc.org/github.com/ooni/netx/modelx)
 
 The base package, that defines everything that other packages
 will use. Among others, it defines the measurement model.

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -1,4 +1,4 @@
-// Package handlers contains default model.Handler handlers.
+// Package handlers contains default modelx.Handler handlers.
 package handlers
 
 import (
@@ -6,12 +6,12 @@ import (
 	"fmt"
 
 	"github.com/m-lab/go/rtx"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 type stdoutHandler struct{}
 
-func (stdoutHandler) OnMeasurement(m model.Measurement) {
+func (stdoutHandler) OnMeasurement(m modelx.Measurement) {
 	data, err := json.Marshal(m)
 	rtx.Must(err, "unexpected json.Marshal failure")
 	fmt.Printf("%s\n", string(data))
@@ -22,7 +22,7 @@ var StdoutHandler stdoutHandler
 
 type noHandler struct{}
 
-func (noHandler) OnMeasurement(m model.Measurement) {
+func (noHandler) OnMeasurement(m modelx.Measurement) {
 }
 
 // NoHandler is a Handler that does not print anything

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 
 	"github.com/ooni/netx/handlers"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 func TestIntegration(t *testing.T) {
-	handlers.NoHandler.OnMeasurement(model.Measurement{})
-	handlers.StdoutHandler.OnMeasurement(model.Measurement{})
+	handlers.NoHandler.OnMeasurement(modelx.Measurement{})
+	handlers.StdoutHandler.OnMeasurement(modelx.Measurement{})
 }

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/internal"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // Transport performs measurements during HTTP round trips.
@@ -20,7 +20,7 @@ type Transport struct {
 }
 
 func newTransport(
-	beginning time.Time, handler model.Handler,
+	beginning time.Time, handler modelx.Handler,
 	proxyFunc func(*http.Request) (*url.URL, error),
 ) *Transport {
 	t := new(Transport)
@@ -45,7 +45,7 @@ func NewTransportWithProxyFunc(
 
 // NewTransport creates a new Transport. The beginning argument is
 // the time to use as zero for computing the elapsed time.
-func NewTransport(beginning time.Time, handler model.Handler) *Transport {
+func NewTransport(beginning time.Time, handler modelx.Handler) *Transport {
 	return newTransport(beginning, handler, http.ProxyFromEnvironment)
 }
 
@@ -68,7 +68,7 @@ func (t *Transport) ConfigureDNS(network, address string) error {
 }
 
 // SetResolver is exactly like netx.Dialer.SetResolver.
-func (t *Transport) SetResolver(r model.DNSResolver) {
+func (t *Transport) SetResolver(r modelx.DNSResolver) {
 	t.dialer.SetResolver(r)
 }
 
@@ -95,7 +95,7 @@ type Client struct {
 }
 
 func newClient(
-	handler model.Handler,
+	handler modelx.Handler,
 	proxyFunc func(*http.Request) (*url.URL, error),
 ) *Client {
 	transport := newTransport(time.Now(), handler, proxyFunc)
@@ -108,7 +108,7 @@ func newClient(
 }
 
 // NewClient creates a new client instance.
-func NewClient(handler model.Handler) *Client {
+func NewClient(handler modelx.Handler) *Client {
 	return newClient(handler, http.ProxyFromEnvironment)
 }
 
@@ -116,7 +116,7 @@ func NewClient(handler model.Handler) *Client {
 // configured proxy attached to it. This is suitable
 // for measurements where you don't want a proxy to be
 // in the middle and alter the measurements.
-func NewClientWithoutProxy(handler model.Handler) *Client {
+func NewClientWithoutProxy(handler modelx.Handler) *Client {
 	return newClient(handler, nil)
 }
 
@@ -127,7 +127,7 @@ func (c *Client) ConfigureDNS(network, address string) error {
 }
 
 // SetResolver internally calls netx.Dialer.SetResolver
-func (c *Client) SetResolver(r model.DNSResolver) {
+func (c *Client) SetResolver(r modelx.DNSResolver) {
 	c.Transport.SetResolver(r)
 }
 

--- a/internal/dialer/connx/connx.go
+++ b/internal/dialer/connx/connx.go
@@ -6,14 +6,14 @@ import (
 	"time"
 
 	"github.com/ooni/netx/internal/errwrapper"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // MeasuringConn is a net.Conn used to perform measurements
 type MeasuringConn struct {
 	net.Conn
 	Beginning time.Time
-	Handler   model.Handler
+	Handler   modelx.Handler
 	ID        int64
 }
 
@@ -27,8 +27,8 @@ func (c *MeasuringConn) Read(b []byte) (n int, err error) {
 		Operation: "read",
 	}.MaybeBuild()
 	stop := time.Now()
-	c.Handler.OnMeasurement(model.Measurement{
-		Read: &model.ReadEvent{
+	c.Handler.OnMeasurement(modelx.Measurement{
+		Read: &modelx.ReadEvent{
 			ConnID:                 c.ID,
 			DurationSinceBeginning: stop.Sub(c.Beginning),
 			Error:                  err,
@@ -49,8 +49,8 @@ func (c *MeasuringConn) Write(b []byte) (n int, err error) {
 		Operation: "write",
 	}.MaybeBuild()
 	stop := time.Now()
-	c.Handler.OnMeasurement(model.Measurement{
-		Write: &model.WriteEvent{
+	c.Handler.OnMeasurement(modelx.Measurement{
+		Write: &modelx.WriteEvent{
 			ConnID:                 c.ID,
 			DurationSinceBeginning: stop.Sub(c.Beginning),
 			Error:                  err,
@@ -71,8 +71,8 @@ func (c *MeasuringConn) Close() (err error) {
 		Operation: "close",
 	}.MaybeBuild()
 	stop := time.Now()
-	c.Handler.OnMeasurement(model.Measurement{
-		Close: &model.CloseEvent{
+	c.Handler.OnMeasurement(modelx.Measurement{
+		Close: &modelx.CloseEvent{
 			ConnID:                 c.ID,
 			DurationSinceBeginning: stop.Sub(c.Beginning),
 			Error:                  err,

--- a/internal/dialer/dialer.go
+++ b/internal/dialer/dialer.go
@@ -7,15 +7,15 @@ import (
 
 	"github.com/ooni/netx/internal/dialer/dnsdialer"
 	"github.com/ooni/netx/internal/dialer/tlsdialer"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
-// New creates a new model.Dialer
-func New(resolver model.DNSResolver, dialer model.Dialer) *dnsdialer.Dialer {
+// New creates a new modelx.Dialer
+func New(resolver modelx.DNSResolver, dialer modelx.Dialer) *dnsdialer.Dialer {
 	return dnsdialer.New(resolver, dialer)
 }
 
-// NewTLS creates a new model.TLSDialer
-func NewTLS(dialer model.Dialer, config *tls.Config) *tlsdialer.TLSDialer {
+// NewTLS creates a new modelx.TLSDialer
+func NewTLS(dialer modelx.Dialer, config *tls.Config) *tlsdialer.TLSDialer {
 	return tlsdialer.New(dialer, config)
 }

--- a/internal/dialer/dialer_test.go
+++ b/internal/dialer/dialer_test.go
@@ -5,11 +5,11 @@ import (
 	"net"
 	"testing"
 
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 func TestIntegrationNew(t *testing.T) {
-	var dialer model.Dialer = New(new(net.Resolver), new(net.Dialer))
+	var dialer modelx.Dialer = New(new(net.Resolver), new(net.Dialer))
 	conn, err := dialer.Dial("tcp", "www.kernel.org:80")
 	if err != nil {
 		t.Fatal(err)
@@ -21,7 +21,7 @@ func TestIntegrationNew(t *testing.T) {
 }
 
 func TestIntegrationNewTLS(t *testing.T) {
-	var dialer model.TLSDialer = NewTLS(new(net.Dialer), new(tls.Config))
+	var dialer modelx.TLSDialer = NewTLS(new(net.Dialer), new(tls.Config))
 	conn, err := dialer.DialTLS("tcp", "www.kernel.org:443")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/dialer/dialerbase/dialerbase.go
+++ b/internal/dialer/dialerbase/dialerbase.go
@@ -11,23 +11,23 @@ import (
 	"github.com/ooni/netx/internal/dialer/connx"
 	"github.com/ooni/netx/internal/errwrapper"
 	"github.com/ooni/netx/internal/transactionid"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // Dialer is a net.Dialer that is only able to connect to
 // remote TCP/UDP endpoints. DNS is not supported.
 type Dialer struct {
-	dialer    model.Dialer
+	dialer    modelx.Dialer
 	beginning time.Time
-	handler   model.Handler
+	handler   modelx.Handler
 	dialID    int64
 }
 
 // New creates a new dialer
 func New(
 	beginning time.Time,
-	handler model.Handler,
-	dialer model.Dialer,
+	handler modelx.Handler,
+	dialer modelx.Dialer,
 	dialID int64,
 ) *Dialer {
 	return &Dialer{
@@ -62,8 +62,8 @@ func (d *Dialer) DialContext(
 	}.MaybeBuild()
 	connID := safeConnID(network, conn)
 	txID := transactionid.ContextTransactionID(ctx)
-	d.handler.OnMeasurement(model.Measurement{
-		Connect: &model.ConnectEvent{
+	d.handler.OnMeasurement(modelx.Measurement{
+		Connect: &modelx.ConnectEvent{
 			ConnID:                 connID,
 			DialID:                 d.dialID,
 			DurationSinceBeginning: stop.Sub(d.beginning),

--- a/internal/dialer/dialerbase/dialerbase_test.go
+++ b/internal/dialer/dialerbase/dialerbase_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/ooni/netx/handlers"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 func TestIntegrationSuccess(t *testing.T) {
@@ -36,7 +36,7 @@ func TestIntegrationErrorNoConnect(t *testing.T) {
 }
 
 // see whether we implement the interface
-func newdialer() model.Dialer {
+func newdialer() modelx.Dialer {
 	return New(
 		time.Now(), handlers.NoHandler, new(net.Dialer), 17,
 	)

--- a/internal/dialer/dnsdialer/dnsdialer.go
+++ b/internal/dialer/dnsdialer/dnsdialer.go
@@ -9,18 +9,18 @@ import (
 
 	"github.com/ooni/netx/internal/dialer/dialerbase"
 	"github.com/ooni/netx/internal/dialid"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // Dialer defines the dialer API. We implement the most basic form
 // of DNS, but more advanced resolutions are possible.
 type Dialer struct {
-	dialer   model.Dialer
-	resolver model.DNSResolver
+	dialer   modelx.Dialer
+	resolver modelx.DNSResolver
 }
 
 // New creates a new Dialer.
-func New(resolver model.DNSResolver, dialer model.Dialer) (d *Dialer) {
+func New(resolver modelx.DNSResolver, dialer modelx.Dialer) (d *Dialer) {
 	return &Dialer{
 		dialer:   dialer,
 		resolver: resolver,
@@ -37,7 +37,7 @@ func (d *Dialer) Dial(network, address string) (net.Conn, error) {
 func (d *Dialer) DialContext(
 	ctx context.Context, network, address string,
 ) (conn net.Conn, err error) {
-	root := model.ContextMeasurementRootOrDefault(ctx)
+	root := modelx.ContextMeasurementRootOrDefault(ctx)
 	onlyhost, onlyport, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func reduceErrors(errorslist []error) error {
 	// the user has no IPv6 connectivity, an IPv6 error is going to
 	// appear later in the list of errors.
 	for _, err := range errorslist {
-		var wrapper *model.ErrWrapper
+		var wrapper *modelx.ErrWrapper
 		if errors.As(err, &wrapper) && !strings.HasPrefix(
 			err.Error(), "unknown_error",
 		) {
@@ -93,7 +93,7 @@ func (d *Dialer) lookupHost(
 	if net.ParseIP(hostname) != nil {
 		return []string{hostname}, nil
 	}
-	root := model.ContextMeasurementRootOrDefault(ctx)
+	root := modelx.ContextMeasurementRootOrDefault(ctx)
 	lookupHost := root.LookupHost
 	if root.LookupHost == nil {
 		lookupHost = d.resolver.LookupHost

--- a/internal/dialer/dnsdialer/dnsdialer_test.go
+++ b/internal/dialer/dnsdialer/dnsdialer_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/ooni/netx/handlers"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 func TestIntegrationDial(t *testing.T) {
@@ -66,7 +66,7 @@ func TestIntegrationDialTCPFailure(t *testing.T) {
 	}
 }
 
-func newdialer() model.Dialer {
+func newdialer() modelx.Dialer {
 	return New(new(net.Resolver), new(net.Dialer))
 }
 
@@ -97,10 +97,10 @@ func TestReduceErrors(t *testing.T) {
 
 	t.Run("multiple errors with meaningful ones", func(t *testing.T) {
 		err1 := errors.New("mocked error #1")
-		err2 := &model.ErrWrapper{
+		err2 := &modelx.ErrWrapper{
 			Failure: "unknown_error: antani",
 		}
-		err3 := &model.ErrWrapper{
+		err3 := &modelx.ErrWrapper{
 			Failure: "connection_refused",
 		}
 		err4 := errors.New("mocked error #3")
@@ -114,14 +114,14 @@ func TestReduceErrors(t *testing.T) {
 func TestIntegrationDivertLookupHost(t *testing.T) {
 	dialer := newdialer()
 	failure := errors.New("mocked error")
-	root := &model.MeasurementRoot{
+	root := &modelx.MeasurementRoot{
 		Beginning: time.Now(),
 		Handler:   handlers.NoHandler,
 		LookupHost: func(ctx context.Context, hostname string) ([]string, error) {
 			return nil, failure
 		},
 	}
-	ctx := model.WithMeasurementRoot(context.Background(), root)
+	ctx := modelx.WithMeasurementRoot(context.Background(), root)
 	conn, err := dialer.DialContext(ctx, "tcp", "google.com:443")
 	if err == nil {
 		t.Fatal("expected an error here")

--- a/internal/dialer/tlsdialer/tlsdialer.go
+++ b/internal/dialer/tlsdialer/tlsdialer.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ooni/netx/internal/dialer/connx"
 	"github.com/ooni/netx/internal/errwrapper"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // TLSDialer is the TLS dialer
@@ -17,12 +17,12 @@ type TLSDialer struct {
 	ConnectTimeout      time.Duration // default: 30 second
 	TLSHandshakeTimeout time.Duration // default: 10 second
 	config              *tls.Config
-	dialer              model.Dialer
+	dialer              modelx.Dialer
 	setDeadline         func(net.Conn, time.Time) error
 }
 
 // New creates a new TLS dialer
-func New(dialer model.Dialer, config *tls.Config) *TLSDialer {
+func New(dialer modelx.Dialer, config *tls.Config) *TLSDialer {
 	return &TLSDialer{
 		ConnectTimeout:      30 * time.Second,
 		TLSHandshakeTimeout: 10 * time.Second,
@@ -68,13 +68,13 @@ func (d *TLSDialer) DialTLSContext(
 	if mconn, ok := conn.(*connx.MeasuringConn); ok {
 		connID = mconn.ID
 	}
-	root := model.ContextMeasurementRootOrDefault(ctx)
+	root := modelx.ContextMeasurementRootOrDefault(ctx)
 	// Implementation note: when DialTLS is not set, the code in
 	// net/http will perform the handshake. Otherwise, if DialTLS
 	// is set, we will end up here. This code is still used when
 	// performing non-HTTP TLS-enabled dial operations.
-	root.Handler.OnMeasurement(model.Measurement{
-		TLSHandshakeStart: &model.TLSHandshakeStartEvent{
+	root.Handler.OnMeasurement(modelx.Measurement{
+		TLSHandshakeStart: &modelx.TLSHandshakeStartEvent{
 			ConnID:                 connID,
 			DurationSinceBeginning: time.Now().Sub(root.Beginning),
 		},
@@ -85,10 +85,10 @@ func (d *TLSDialer) DialTLSContext(
 		Error:     err,
 		Operation: "tls_handshake",
 	}.MaybeBuild()
-	root.Handler.OnMeasurement(model.Measurement{
-		TLSHandshakeDone: &model.TLSHandshakeDoneEvent{
+	root.Handler.OnMeasurement(modelx.Measurement{
+		TLSHandshakeDone: &modelx.TLSHandshakeDoneEvent{
 			ConnID:                 connID,
-			ConnectionState:        model.NewTLSConnectionState(tlsconn.ConnectionState()),
+			ConnectionState:        modelx.NewTLSConnectionState(tlsconn.ConnectionState()),
 			Error:                  err,
 			DurationSinceBeginning: time.Now().Sub(root.Beginning),
 		},

--- a/internal/dialer/tlsdialer/tlsdialer_test.go
+++ b/internal/dialer/tlsdialer/tlsdialer_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/internal/dialer/dialerbase"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 func TestIntegrationSuccess(t *testing.T) {
@@ -88,6 +88,6 @@ func TestIntegrationFailureSetDeadline(t *testing.T) {
 	}
 }
 
-func newdialer() model.TLSDialer {
+func newdialer() modelx.TLSDialer {
 	return New(new(net.Dialer), new(tls.Config))
 }

--- a/internal/errwrapper/errwrapper.go
+++ b/internal/errwrapper/errwrapper.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // ErrDNSBogon indicates that we found a bogon address
 var ErrDNSBogon = errors.New("dns: detected bogon address")
 
-// SafeErrWrapperBuilder contains a builder for model.ErrWrapper that
+// SafeErrWrapperBuilder contains a builder for modelx.ErrWrapper that
 // is safe, i.e., behaves correctly when the error is nil.
 type SafeErrWrapperBuilder struct {
 	// ConnID is the connection ID, if any
@@ -32,11 +32,11 @@ type SafeErrWrapperBuilder struct {
 	TransactionID int64
 }
 
-// MaybeBuild builds a new model.ErrWrapper, if b.Error is not nil, and returns
+// MaybeBuild builds a new modelx.ErrWrapper, if b.Error is not nil, and returns
 // a nil error value, instead, if b.Error is nil.
 func (b SafeErrWrapperBuilder) MaybeBuild() (err error) {
 	if b.Error != nil {
-		err = &model.ErrWrapper{
+		err = &modelx.ErrWrapper{
 			ConnID:        b.ConnID,
 			DialID:        b.DialID,
 			Failure:       toFailureString(b.Error),
@@ -52,7 +52,7 @@ func toFailureString(err error) string {
 	// The list returned here matches the values used by MK unless
 	// explicitly noted otherwise with a comment.
 
-	var errwrapper *model.ErrWrapper
+	var errwrapper *modelx.ErrWrapper
 	if errors.As(err, &errwrapper) {
 		return errwrapper.Error() // we've already wrapped it
 	}
@@ -108,9 +108,9 @@ func toFailureString(err error) string {
 }
 
 func toOperationString(err error, operation string) string {
-	var errwrapper *model.ErrWrapper
+	var errwrapper *modelx.ErrWrapper
 	if errors.As(err, &errwrapper) {
-		// Basically, as explained in model.ErrWrapper docs, let's
+		// Basically, as explained in modelx.ErrWrapper docs, let's
 		// keep the child major operation, if any.
 		if errwrapper.Operation == "connect" {
 			return errwrapper.Operation

--- a/internal/errwrapper/errwrapper_test.go
+++ b/internal/errwrapper/errwrapper_test.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 func TestMaybeBuildFactory(t *testing.T) {
@@ -19,7 +19,7 @@ func TestMaybeBuildFactory(t *testing.T) {
 		Error:         errors.New("mocked error"),
 		TransactionID: 100,
 	}.MaybeBuild()
-	var target *model.ErrWrapper
+	var target *modelx.ErrWrapper
 	if errors.As(err, &target) == false {
 		t.Fatal("not the expected error type")
 	}
@@ -126,7 +126,7 @@ func TestUnitToOperationString(t *testing.T) {
 	t.Run("for connect", func(t *testing.T) {
 		// You're doing HTTP and connect fails. You want to know
 		// that connect failed not that HTTP failed.
-		err := &model.ErrWrapper{Operation: "connect"}
+		err := &modelx.ErrWrapper{Operation: "connect"}
 		if toOperationString(err, "http_round_trip") != "connect" {
 			t.Fatal("unexpected result")
 		}
@@ -134,7 +134,7 @@ func TestUnitToOperationString(t *testing.T) {
 	t.Run("for http_round_trip", func(t *testing.T) {
 		// You're doing DoH and something fails inside HTTP. You want
 		// to know about the internal HTTP error, not resolve.
-		err := &model.ErrWrapper{Operation: "http_round_trip"}
+		err := &modelx.ErrWrapper{Operation: "http_round_trip"}
 		if toOperationString(err, "resolve") != "http_round_trip" {
 			t.Fatal("unexpected result")
 		}
@@ -142,7 +142,7 @@ func TestUnitToOperationString(t *testing.T) {
 	t.Run("for resolve", func(t *testing.T) {
 		// You're doing HTTP and the DNS fails. You want to
 		// know that resolve failed.
-		err := &model.ErrWrapper{Operation: "resolve"}
+		err := &modelx.ErrWrapper{Operation: "resolve"}
 		if toOperationString(err, "http_round_trip") != "resolve" {
 			t.Fatal("unexpected result")
 		}
@@ -150,7 +150,7 @@ func TestUnitToOperationString(t *testing.T) {
 	t.Run("for tls_handshake", func(t *testing.T) {
 		// You're doing HTTP and the TLS handshake fails. You want
 		// to know about a TLS handshake error.
-		err := &model.ErrWrapper{Operation: "tls_handshake"}
+		err := &modelx.ErrWrapper{Operation: "tls_handshake"}
 		if toOperationString(err, "http_round_trip") != "tls_handshake" {
 			t.Fatal("unexpected result")
 		}
@@ -159,7 +159,7 @@ func TestUnitToOperationString(t *testing.T) {
 		// You just noticed that TLS handshake failed and you
 		// have a child error telling you that read failed. Here
 		// you want to know about a TLS handshake error.
-		err := &model.ErrWrapper{Operation: "read"}
+		err := &modelx.ErrWrapper{Operation: "read"}
 		if toOperationString(err, "tls_handshake") != "tls_handshake" {
 			t.Fatal("unexpected result")
 		}

--- a/internal/httptransport/tracetripper/tracetripper_test.go
+++ b/internal/httptransport/tracetripper/tracetripper_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 func TestIntegration(t *testing.T) {
@@ -33,11 +33,11 @@ func TestIntegration(t *testing.T) {
 }
 
 type roundTripHandler struct {
-	roundTrips []*model.HTTPRoundTripDoneEvent
+	roundTrips []*modelx.HTTPRoundTripDoneEvent
 	mu         sync.Mutex
 }
 
-func (h *roundTripHandler) OnMeasurement(m model.Measurement) {
+func (h *roundTripHandler) OnMeasurement(m modelx.Measurement) {
 	if m.HTTPRoundTripDone != nil {
 		h.mu.Lock()
 		defer h.mu.Unlock()
@@ -139,8 +139,8 @@ func TestIntegrationWithCorrectSnaps(t *testing.T) {
 	}
 	req.Header.Set("Content-Type", "application/dns-message")
 	handler := &roundTripHandler{}
-	ctx := model.WithMeasurementRoot(
-		context.Background(), &model.MeasurementRoot{
+	ctx := modelx.WithMeasurementRoot(
+		context.Background(), &modelx.MeasurementRoot{
 			Beginning: time.Now(),
 			Handler:   handler,
 		},
@@ -247,8 +247,8 @@ func TestIntegrationWithReadAllFailingForBody(t *testing.T) {
 	}
 	req.Header.Set("Content-Type", "application/dns-message")
 	handler := &roundTripHandler{}
-	ctx := model.WithMeasurementRoot(
-		context.Background(), &model.MeasurementRoot{
+	ctx := modelx.WithMeasurementRoot(
+		context.Background(), &modelx.MeasurementRoot{
 			Beginning: time.Now(),
 			Handler:   handler,
 		},

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ooni/netx/internal/httptransport"
 	"github.com/ooni/netx/internal/resolver"
 	"github.com/ooni/netx/internal/resolver/chainresolver"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 	"golang.org/x/net/http2"
 )
 
@@ -27,14 +27,14 @@ import (
 // of DNS, but more advanced resolutions are possible.
 type Dialer struct {
 	Beginning time.Time
-	Handler   model.Handler
-	Resolver  model.DNSResolver
+	Handler   modelx.Handler
+	Resolver  modelx.DNSResolver
 	TLSConfig *tls.Config
 }
 
 // NewDialer creates a new Dialer.
 func NewDialer(
-	beginning time.Time, handler model.Handler,
+	beginning time.Time, handler modelx.Handler,
 ) (d *Dialer) {
 	return &Dialer{
 		Beginning: beginning,
@@ -50,12 +50,12 @@ func (d *Dialer) Dial(network, address string) (net.Conn, error) {
 }
 
 func maybeWithMeasurementRoot(
-	ctx context.Context, beginning time.Time, handler model.Handler,
+	ctx context.Context, beginning time.Time, handler modelx.Handler,
 ) context.Context {
-	if model.ContextMeasurementRoot(ctx) != nil {
+	if modelx.ContextMeasurementRoot(ctx) != nil {
 		return ctx
 	}
-	return model.WithMeasurementRoot(ctx, &model.MeasurementRoot{
+	return modelx.WithMeasurementRoot(ctx, &modelx.MeasurementRoot{
 		Beginning: beginning,
 		Handler:   handler,
 	})
@@ -117,7 +117,7 @@ func (d *Dialer) ConfigureDNS(network, address string) error {
 }
 
 // SetResolver implements netx.Dialer.SetResolver.
-func (d *Dialer) SetResolver(r model.DNSResolver) {
+func (d *Dialer) SetResolver(r modelx.DNSResolver) {
 	d.Resolver = r
 }
 
@@ -126,7 +126,7 @@ var (
 	dohClientOnce   sync.Once
 )
 
-func newHTTPClientForDoH(beginning time.Time, handler model.Handler) *http.Client {
+func newHTTPClientForDoH(beginning time.Time, handler modelx.Handler) *http.Client {
 	if handler == handlers.NoHandler {
 		// A bit of extra complexity for a good reason: if the user is not
 		// interested into setting a default handler, then it is fine to
@@ -171,13 +171,13 @@ func withPort(address, port string) string {
 
 type resolverWrapper struct {
 	beginning time.Time
-	handler   model.Handler
-	resolver  model.DNSResolver
+	handler   modelx.Handler
+	resolver  modelx.DNSResolver
 }
 
 func newResolverWrapper(
-	beginning time.Time, handler model.Handler,
-	resolver model.DNSResolver,
+	beginning time.Time, handler modelx.Handler,
+	resolver modelx.DNSResolver,
 ) *resolverWrapper {
 	return &resolverWrapper{
 		beginning: beginning,
@@ -218,8 +218,8 @@ func (r *resolverWrapper) LookupNS(ctx context.Context, name string) ([]*net.NS,
 
 // NewResolver returns a new resolver
 func NewResolver(
-	beginning time.Time, handler model.Handler, network, address string,
-) (model.DNSResolver, error) {
+	beginning time.Time, handler modelx.Handler, network, address string,
+) (modelx.DNSResolver, error) {
 	// Implementation note: system need to be dealt with
 	// separately because it doesn't have any transport.
 	if network == "system" || network == "" {
@@ -258,7 +258,7 @@ func NewResolver(
 // measurement events as they happen.
 type HTTPTransport struct {
 	Transport    *http.Transport
-	Handler      model.Handler
+	Handler      modelx.Handler
 	Beginning    time.Time
 	roundTripper http.RoundTripper
 }
@@ -266,7 +266,7 @@ type HTTPTransport struct {
 // NewHTTPTransport creates a new Transport.
 func NewHTTPTransport(
 	beginning time.Time,
-	handler model.Handler,
+	handler modelx.Handler,
 	dialer *Dialer,
 	disableKeepAlives bool,
 	proxyFunc func(*http.Request) (*url.URL, error),
@@ -335,6 +335,6 @@ func (t *HTTPTransport) CloseIdleConnections() {
 
 // ChainResolvers chains a primary and a secondary resolver such that
 // we can fallback to the secondary if primary is broken.
-func ChainResolvers(primary, secondary model.DNSResolver) model.DNSResolver {
+func ChainResolvers(primary, secondary modelx.DNSResolver) modelx.DNSResolver {
 	return chainresolver.New(primary, secondary)
 }

--- a/internal/resolver/chainresolver/chainresolver.go
+++ b/internal/resolver/chainresolver/chainresolver.go
@@ -5,17 +5,17 @@ import (
 	"context"
 	"net"
 
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // Resolver is a chain resolver.
 type Resolver struct {
-	primary   model.DNSResolver
-	secondary model.DNSResolver
+	primary   modelx.DNSResolver
+	secondary modelx.DNSResolver
 }
 
 // New creates a new chain Resolver instance.
-func New(primary, secondary model.DNSResolver) *Resolver {
+func New(primary, secondary modelx.DNSResolver) *Resolver {
 	return &Resolver{
 		primary:   primary,
 		secondary: secondary,

--- a/internal/resolver/dnstransport/dnsoverhttps/dnsoverhttps.go
+++ b/internal/resolver/dnstransport/dnsoverhttps/dnsoverhttps.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 )
 
-// Transport is a DNS over HTTPS model.DNSRoundTripper.
+// Transport is a DNS over HTTPS modelx.DNSRoundTripper.
 //
 // As a known bug, this implementation does not cache the domain
 // name in the URL for reuse, but this should be easy to fix.

--- a/internal/resolver/dnstransport/dnsovertcp/dnsovertcp.go
+++ b/internal/resolver/dnstransport/dnsovertcp/dnsovertcp.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/m-lab/go/rtx"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
-// Transport is a DNS over TCP/TLS model.DNSRoundTripper.
+// Transport is a DNS over TCP/TLS modelx.DNSRoundTripper.
 //
 // As a known bug, this implementation always creates a new connection
 // for each incoming query, thus increasing the response delay.
@@ -23,12 +23,12 @@ type Transport struct {
 }
 
 type dialerAdapter interface {
-	model.Dialer
+	modelx.Dialer
 	Network() string
 }
 
 // NewTransportTCP creates a new TCP Transport
-func NewTransportTCP(dialer model.Dialer, address string) *Transport {
+func NewTransportTCP(dialer modelx.Dialer, address string) *Transport {
 	return &Transport{
 		dialer:  newTCPDialerAdapter(dialer),
 		address: address,
@@ -36,7 +36,7 @@ func NewTransportTCP(dialer model.Dialer, address string) *Transport {
 }
 
 // NewTransportTLS creates a new TLS Transport
-func NewTransportTLS(dialer model.TLSDialer, address string) *Transport {
+func NewTransportTLS(dialer modelx.TLSDialer, address string) *Transport {
 	return &Transport{
 		dialer:  newTLSDialerAdapter(dialer),
 		address: address,
@@ -83,10 +83,10 @@ func (t *Transport) doWithConn(conn net.Conn, query []byte) (reply []byte, err e
 }
 
 type tlsDialerAdapter struct {
-	dialer model.TLSDialer
+	dialer modelx.TLSDialer
 }
 
-func newTLSDialerAdapter(dialer model.TLSDialer) *tlsDialerAdapter {
+func newTLSDialerAdapter(dialer modelx.TLSDialer) *tlsDialerAdapter {
 	return &tlsDialerAdapter{dialer: dialer}
 }
 
@@ -105,10 +105,10 @@ func (d *tlsDialerAdapter) Network() string {
 }
 
 type tcpDialerAdapter struct {
-	model.Dialer
+	modelx.Dialer
 }
 
-func newTCPDialerAdapter(dialer model.Dialer) *tcpDialerAdapter {
+func newTCPDialerAdapter(dialer modelx.Dialer) *tcpDialerAdapter {
 	return &tcpDialerAdapter{Dialer: dialer}
 }
 

--- a/internal/resolver/dnstransport/dnsoverudp/dnsoverudp.go
+++ b/internal/resolver/dnstransport/dnsoverudp/dnsoverudp.go
@@ -5,17 +5,17 @@ import (
 	"context"
 	"time"
 
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
-// Transport is a DNS over UDP model.DNSRoundTripper.
+// Transport is a DNS over UDP modelx.DNSRoundTripper.
 type Transport struct {
-	dialer  model.Dialer
+	dialer  modelx.Dialer
 	address string
 }
 
 // NewTransport creates a new Transport
-func NewTransport(dialer model.Dialer, address string) *Transport {
+func NewTransport(dialer modelx.Dialer, address string) *Transport {
 	return &Transport{
 		dialer:  dialer,
 		address: address,

--- a/internal/resolver/ooniresolver/ooniresolver.go
+++ b/internal/resolver/ooniresolver/ooniresolver.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/ooni/netx/internal/dialid"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // Resolver is OONI's DNS client. It is a simplistic client where we
@@ -18,16 +18,16 @@ import (
 // for DNS supported by this library, however.
 type Resolver struct {
 	ntimeouts int64
-	transport model.DNSRoundTripper
+	transport modelx.DNSRoundTripper
 }
 
 // New creates a new OONI Resolver instance.
-func New(t model.DNSRoundTripper) *Resolver {
+func New(t modelx.DNSRoundTripper) *Resolver {
 	return &Resolver{transport: t}
 }
 
 // Transport returns the transport being used.
-func (c *Resolver) Transport() model.DNSRoundTripper {
+func (c *Resolver) Transport() modelx.DNSRoundTripper {
 	return c.transport
 }
 
@@ -140,7 +140,7 @@ func (c *Resolver) roundTrip(ctx context.Context, query *dns.Msg) (reply *dns.Ms
 		ctx, query, func(msg *dns.Msg) ([]byte, error) {
 			return msg.Pack()
 		},
-		func(t model.DNSRoundTripper, query []byte) (reply []byte, err error) {
+		func(t modelx.DNSRoundTripper, query []byte) (reply []byte, err error) {
 			// Pass ctx to round tripper for cancellation as well
 			// as to propagate context information
 			return t.RoundTrip(ctx, query)
@@ -155,7 +155,7 @@ func (c *Resolver) mockableRoundTrip(
 	ctx context.Context,
 	query *dns.Msg,
 	pack func(msg *dns.Msg) ([]byte, error),
-	roundTrip func(t model.DNSRoundTripper, query []byte) (reply []byte, err error),
+	roundTrip func(t modelx.DNSRoundTripper, query []byte) (reply []byte, err error),
 	unpack func(msg *dns.Msg, data []byte) (err error),
 ) (reply *dns.Msg, err error) {
 	var (
@@ -166,9 +166,9 @@ func (c *Resolver) mockableRoundTrip(
 	if err != nil {
 		return
 	}
-	root := model.ContextMeasurementRootOrDefault(ctx)
-	root.Handler.OnMeasurement(model.Measurement{
-		DNSQuery: &model.DNSQueryEvent{
+	root := modelx.ContextMeasurementRootOrDefault(ctx)
+	root.Handler.OnMeasurement(modelx.Measurement{
+		DNSQuery: &modelx.DNSQueryEvent{
 			Data:                   querydata,
 			DialID:                 dialid.ContextDialID(ctx),
 			DurationSinceBeginning: time.Now().Sub(root.Beginning),
@@ -184,8 +184,8 @@ func (c *Resolver) mockableRoundTrip(
 	if err != nil {
 		return
 	}
-	root.Handler.OnMeasurement(model.Measurement{
-		DNSReply: &model.DNSReplyEvent{
+	root.Handler.OnMeasurement(modelx.Measurement{
+		DNSReply: &modelx.DNSReplyEvent{
 			Data:                   replydata,
 			DialID:                 dialid.ContextDialID(ctx),
 			DurationSinceBeginning: time.Now().Sub(root.Beginning),

--- a/internal/resolver/ooniresolver/ooniresolver_test.go
+++ b/internal/resolver/ooniresolver/ooniresolver_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/miekg/dns"
 	"github.com/ooni/netx/internal/resolver/dnstransport/dnsovertcp"
 	"github.com/ooni/netx/internal/resolver/dnstransport/dnsoverudp"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
-func newtransport() model.DNSRoundTripper {
+func newtransport() modelx.DNSRoundTripper {
 	return dnsovertcp.NewTransportTCP(&net.Dialer{}, "dns.quad9.net:53")
 }
 
@@ -149,7 +149,7 @@ func TestRoundTripExPackFailure(t *testing.T) {
 		func(msg *dns.Msg) ([]byte, error) {
 			return nil, errors.New("mocked error")
 		},
-		func(t model.DNSRoundTripper, query []byte) (reply []byte, err error) {
+		func(t modelx.DNSRoundTripper, query []byte) (reply []byte, err error) {
 			return nil, nil
 		},
 		func(msg *dns.Msg, data []byte) (err error) {
@@ -168,7 +168,7 @@ func TestRoundTripExRoundTripFailure(t *testing.T) {
 		func(msg *dns.Msg) ([]byte, error) {
 			return nil, nil
 		},
-		func(t model.DNSRoundTripper, query []byte) (reply []byte, err error) {
+		func(t modelx.DNSRoundTripper, query []byte) (reply []byte, err error) {
 			return nil, errors.New("mocked error")
 		},
 		func(msg *dns.Msg, data []byte) (err error) {
@@ -187,7 +187,7 @@ func TestRoundTripExUnpackFailure(t *testing.T) {
 		func(msg *dns.Msg) ([]byte, error) {
 			return nil, nil
 		},
-		func(t model.DNSRoundTripper, query []byte) (reply []byte, err error) {
+		func(t modelx.DNSRoundTripper, query []byte) (reply []byte, err error) {
 			return nil, nil
 		},
 		func(msg *dns.Msg, data []byte) (err error) {

--- a/internal/resolver/parentresolver/parentresolver.go
+++ b/internal/resolver/parentresolver/parentresolver.go
@@ -12,18 +12,18 @@ import (
 	"github.com/ooni/netx/internal/errwrapper"
 	"github.com/ooni/netx/internal/resolver/bogondetector"
 	"github.com/ooni/netx/internal/transactionid"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 	"github.com/ooni/netx/x/scoreboard"
 )
 
 // Resolver is the emitter resolver
 type Resolver struct {
 	bogonsCount int64
-	resolver    model.DNSResolver
+	resolver    modelx.DNSResolver
 }
 
 // New creates a new emitter resolver
-func New(resolver model.DNSResolver) *Resolver {
+func New(resolver modelx.DNSResolver) *Resolver {
 	return &Resolver{resolver: resolver}
 }
 
@@ -43,7 +43,7 @@ type queryableTransport interface {
 }
 
 type queryableResolver interface {
-	Transport() model.DNSRoundTripper
+	Transport() modelx.DNSRoundTripper
 }
 
 func (r *Resolver) queryTransport() (network string, address string) {
@@ -60,9 +60,9 @@ func (r *Resolver) LookupHost(ctx context.Context, hostname string) ([]string, e
 	network, address := r.queryTransport()
 	dialID := dialid.ContextDialID(ctx)
 	txID := transactionid.ContextTransactionID(ctx)
-	root := model.ContextMeasurementRootOrDefault(ctx)
-	root.Handler.OnMeasurement(model.Measurement{
-		ResolveStart: &model.ResolveStartEvent{
+	root := modelx.ContextMeasurementRootOrDefault(ctx)
+	root.Handler.OnMeasurement(modelx.Measurement{
+		ResolveStart: &modelx.ResolveStartEvent{
 			DialID:                 dialID,
 			DurationSinceBeginning: time.Now().Sub(root.Beginning),
 			Hostname:               hostname,
@@ -78,8 +78,8 @@ func (r *Resolver) LookupHost(ctx context.Context, hostname string) ([]string, e
 		Operation:     "resolve",
 		TransactionID: txID,
 	}.MaybeBuild()
-	root.Handler.OnMeasurement(model.Measurement{
-		ResolveDone: &model.ResolveDoneEvent{
+	root.Handler.OnMeasurement(modelx.Measurement{
+		ResolveDone: &modelx.ResolveDoneEvent{
 			Addresses:              addrs,
 			DialID:                 dialID,
 			DurationSinceBeginning: time.Now().Sub(root.Beginning),
@@ -112,7 +112,7 @@ func (r *Resolver) detectedBogon(
 	ctx context.Context, hostname string, addrs []string,
 ) ([]string, error) {
 	atomic.AddInt64(&r.bogonsCount, 1)
-	root := model.ContextMeasurementRootOrDefault(ctx)
+	root := modelx.ContextMeasurementRootOrDefault(ctx)
 	durationSinceBeginning := time.Now().Sub(root.Beginning)
 	root.X.Scoreboard.AddDNSBogonInfo(scoreboard.DNSBogonInfo{
 		Addresses:              addrs,

--- a/internal/resolver/parentresolver/parentresolver_test.go
+++ b/internal/resolver/parentresolver/parentresolver_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/ooni/netx/internal/resolver/systemresolver"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 func TestLookupAddr(t *testing.T) {
@@ -39,7 +39,7 @@ type emitterchecker struct {
 	mu              sync.Mutex
 }
 
-func (h *emitterchecker) OnMeasurement(m model.Measurement) {
+func (h *emitterchecker) OnMeasurement(m modelx.Measurement) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if m.ResolveStart != nil {
@@ -53,8 +53,8 @@ func (h *emitterchecker) OnMeasurement(m model.Measurement) {
 func TestLookupHost(t *testing.T) {
 	client := New(systemresolver.New(new(net.Resolver)))
 	handler := new(emitterchecker)
-	ctx := model.WithMeasurementRoot(
-		context.Background(), &model.MeasurementRoot{
+	ctx := modelx.WithMeasurementRoot(
+		context.Background(), &modelx.MeasurementRoot{
 			Beginning: time.Now(),
 			Handler:   handler,
 		})
@@ -78,8 +78,8 @@ func TestLookupHost(t *testing.T) {
 func TestLookupHostBogon(t *testing.T) {
 	client := New(systemresolver.New(new(net.Resolver)))
 	handler := new(emitterchecker)
-	ctx := model.WithMeasurementRoot(
-		context.Background(), &model.MeasurementRoot{
+	ctx := modelx.WithMeasurementRoot(
+		context.Background(), &modelx.MeasurementRoot{
 			Beginning: time.Now(),
 			Handler:   handler,
 		})
@@ -93,7 +93,7 @@ func TestLookupHostBogon(t *testing.T) {
 	if addrs != nil {
 		t.Fatal("expected nil addr here")
 	}
-	root := model.ContextMeasurementRoot(ctx)
+	root := modelx.ContextMeasurementRoot(ctx)
 	if root.X.Scoreboard.DNSBogonInfo == nil {
 		t.Fatal("no bogon info added to scoreboard")
 	}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ooni/netx/internal/resolver/ooniresolver"
 	"github.com/ooni/netx/internal/resolver/parentresolver"
 	"github.com/ooni/netx/internal/resolver/systemresolver"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // NewResolverSystem creates a new Go/system resolver.
@@ -22,21 +22,21 @@ func NewResolverSystem() *parentresolver.Resolver {
 }
 
 // NewResolverUDP creates a new UDP resolver.
-func NewResolverUDP(dialer model.Dialer, address string) *parentresolver.Resolver {
+func NewResolverUDP(dialer modelx.Dialer, address string) *parentresolver.Resolver {
 	return parentresolver.New(
 		ooniresolver.New(dnsoverudp.NewTransport(dialer, address)),
 	)
 }
 
 // NewResolverTCP creates a new TCP resolver.
-func NewResolverTCP(dialer model.Dialer, address string) *parentresolver.Resolver {
+func NewResolverTCP(dialer modelx.Dialer, address string) *parentresolver.Resolver {
 	return parentresolver.New(
 		ooniresolver.New(dnsovertcp.NewTransportTCP(dialer, address)),
 	)
 }
 
 // NewResolverTLS creates a new DoT resolver.
-func NewResolverTLS(dialer model.TLSDialer, address string) *parentresolver.Resolver {
+func NewResolverTLS(dialer modelx.TLSDialer, address string) *parentresolver.Resolver {
 	return parentresolver.New(
 		ooniresolver.New(dnsovertcp.NewTransportTLS(dialer, address)),
 	)

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
-func testresolverquick(t *testing.T, resolver model.DNSResolver) {
+func testresolverquick(t *testing.T, resolver modelx.DNSResolver) {
 	addrs, err := resolver.LookupHost(context.Background(), "dns.google.com")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/resolver/systemresolver/systemresolver.go
+++ b/internal/resolver/systemresolver/systemresolver.go
@@ -6,16 +6,16 @@ import (
 	"errors"
 	"net"
 
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // Resolver is the system resolver
 type Resolver struct {
-	resolver model.DNSResolver
+	resolver modelx.DNSResolver
 }
 
 // New creates a new system resolver
-func New(resolver model.DNSResolver) *Resolver {
+func New(resolver modelx.DNSResolver) *Resolver {
 	return &Resolver{resolver: resolver}
 }
 
@@ -46,7 +46,7 @@ func (*fakeTransport) Address() string {
 }
 
 // Transport returns the transport being used
-func (r *Resolver) Transport() model.DNSRoundTripper {
+func (r *Resolver) Transport() modelx.DNSRoundTripper {
 	return &fakeTransport{}
 }
 

--- a/internal/resolver/systemresolver/systemresolver_test.go
+++ b/internal/resolver/systemresolver/systemresolver_test.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 type queryableTransport interface {
@@ -14,11 +14,11 @@ type queryableTransport interface {
 }
 
 type queryableResolver interface {
-	Transport() model.DNSRoundTripper
+	Transport() modelx.DNSRoundTripper
 }
 
 func TestCanQuery(t *testing.T) {
-	var client model.DNSResolver = New(new(net.Resolver))
+	var client modelx.DNSResolver = New(new(net.Resolver))
 	transport := client.(queryableResolver).Transport()
 	reply, err := transport.RoundTrip(context.Background(), nil)
 	if err == nil {

--- a/modelx/modelx.go
+++ b/modelx/modelx.go
@@ -1,5 +1,5 @@
-// Package model contains the data model.
-package model
+// Package modelx contains the data modelx.
+package modelx
 
 import (
 	"context"

--- a/modelx/modelx_test.go
+++ b/modelx/modelx_test.go
@@ -1,4 +1,4 @@
-package model
+package modelx
 
 import (
 	"context"

--- a/netx.go
+++ b/netx.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/internal"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 // Dialer performs measurements while dialing.
@@ -21,7 +21,7 @@ type Dialer struct {
 }
 
 // NewDialer returns a new Dialer instance.
-func NewDialer(handler model.Handler) *Dialer {
+func NewDialer(handler modelx.Handler) *Dialer {
 	return &Dialer{
 		dialer: internal.NewDialer(time.Now(), handler),
 	}
@@ -74,7 +74,7 @@ func (d *Dialer) ConfigureDNS(network, address string) error {
 
 // SetResolver is a more flexible way of configuring a resolver
 // that should perhaps be used instead of ConfigureDNS.
-func (d *Dialer) SetResolver(r model.DNSResolver) {
+func (d *Dialer) SetResolver(r modelx.DNSResolver) {
 	d.dialer.SetResolver(r)
 }
 
@@ -109,17 +109,17 @@ func (d *Dialer) DialTLSContext(
 // this Dialer as well. The fact that it's a method of Dialer rather
 // than an independent method is an historical oddity. There is also a
 // standalone NewResolver factory and you should probably use it.
-func (d *Dialer) NewResolver(network, address string) (model.DNSResolver, error) {
+func (d *Dialer) NewResolver(network, address string) (modelx.DNSResolver, error) {
 	return internal.NewResolver(d.dialer.Beginning, d.dialer.Handler, network, address)
 }
 
 // NewResolver is a standalone Dialer.NewResolver
-func NewResolver(handler model.Handler, network, address string) (model.DNSResolver, error) {
+func NewResolver(handler modelx.Handler, network, address string) (modelx.DNSResolver, error) {
 	return internal.NewResolver(time.Now(), handler, network, address)
 }
 
 // NewResolverWithoutHandler creates a standalone Resolver
-func NewResolverWithoutHandler(network, address string) (model.DNSResolver, error) {
+func NewResolverWithoutHandler(network, address string) (modelx.DNSResolver, error) {
 	return internal.NewResolver(time.Now(), handlers.NoHandler, network, address)
 }
 
@@ -137,6 +137,6 @@ func (d *Dialer) ForceSpecificSNI(sni string) error {
 
 // ChainResolvers chains a primary and a secondary resolver such that
 // we can fallback to the secondary if primary is broken.
-func ChainResolvers(primary, secondary model.DNSResolver) model.DNSResolver {
+func ChainResolvers(primary, secondary modelx.DNSResolver) modelx.DNSResolver {
 	return internal.ChainResolvers(primary, secondary)
 }

--- a/x/logger/logger.go
+++ b/x/logger/logger.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/apex/log"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 var (
@@ -32,7 +32,7 @@ func NewHandler(logger log.Interface) *Handler {
 }
 
 // OnMeasurement logs the specific measurement
-func (h *Handler) OnMeasurement(m model.Measurement) {
+func (h *Handler) OnMeasurement(m modelx.Measurement) {
 	// DNS
 	if m.ResolveStart != nil {
 		h.logger.WithFields(log.Fields{

--- a/x/logger/logger_test.go
+++ b/x/logger/logger_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/discard"
 	"github.com/ooni/netx/httpx"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 )
 
 func TestIntegration(t *testing.T) {
@@ -31,7 +31,7 @@ func TestIntegration(t *testing.T) {
 
 func TestExtension(t *testing.T) {
 	logger := NewHandler(log.Log)
-	logger.OnMeasurement(model.Measurement{
-		Extension: &model.ExtensionEvent{},
+	logger.OnMeasurement(modelx.Measurement{
+		Extension: &modelx.ExtensionEvent{},
 	})
 }

--- a/x/porcelain/porcelain_test.go
+++ b/x/porcelain/porcelain_test.go
@@ -7,19 +7,19 @@ import (
 	"time"
 
 	"github.com/ooni/netx/handlers"
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 	"github.com/ooni/netx/x/scoreboard"
 )
 
 func TestUnitChannelHandlerWriteLateOnChannel(t *testing.T) {
 	handler := &channelHandler{
-		ch: make(chan model.Measurement),
+		ch: make(chan modelx.Measurement),
 	}
 	var waitgroup sync.WaitGroup
 	waitgroup.Add(1)
 	go func() {
 		time.Sleep(1 * time.Second)
-		handler.OnMeasurement(model.Measurement{})
+		handler.OnMeasurement(modelx.Measurement{})
 		waitgroup.Done()
 	}()
 	waitgroup.Wait()
@@ -237,7 +237,7 @@ func TestIntegrationTLSConnectUnknownDNS(t *testing.T) {
 func TestMaybeRunTLSChecks(t *testing.T) {
 	out := maybeRunTLSChecks(
 		context.Background(), handlers.NoHandler,
-		&model.XResults{
+		&modelx.XResults{
 			Scoreboard: scoreboard.Board{
 				TLSHandshakeReset: []scoreboard.TLSHandshakeReset{
 					scoreboard.TLSHandshakeReset{

--- a/x/scoreboard/scoreboard_test.go
+++ b/x/scoreboard/scoreboard_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ooni/netx/model"
+	"github.com/ooni/netx/modelx"
 	"github.com/ooni/netx/x/scoreboard"
 )
 
@@ -56,7 +56,7 @@ func TestIntegrationTLSHandshake(t *testing.T) {
 	}, errors.New("connection_reset"))
 	board.MaybeTLSHandshakeReset(11, &url.URL{
 		Host: "www.x.org",
-	}, &model.ErrWrapper{
+	}, &modelx.ErrWrapper{
 		Failure: "connection_reset",
 		WrappedErr: &net.OpError{
 			Addr: &net.TCPAddr{


### PR DESCRIPTION
It otherwise clashes with ooni/probe-engine/model and hence it's
a bit confusing when you quickly read the code.