### PR TITLE
http: always enforce a body snap size

### DIFF
--- a/modelx/modelx.go
+++ b/modelx/modelx.go
@@ -401,9 +401,7 @@ type HTTPRoundTripDoneEvent struct {
 	// ResponseStatusCode contains the HTTP status code if error is nil.
 	ResponseStatusCode int64
 
-	// MaxBodySnapSize is the maximum size of the bodies snapshot. If this
-	// value is negative, we use math.MaxInt64. If the value is zero, we
-	// use a reasonable large value. Otherwise, we'll use this value.
+	// MaxBodySnapSize is the maximum size of the bodies snapshot.
 	MaxBodySnapSize int64
 
 	// TransactionID is the identifier of this transaction
@@ -697,9 +695,9 @@ type MeasurementRoot struct {
 	// MaxBodySnapSize is the maximum size after which we'll stop
 	// reading request and response bodies. They will of course
 	// be fully transmitted, but we'll save only MaxBodySnapSize
-	// bytes as part of the event stream.
-	//
-	// See also HTTPRoundTripDoneEvent.MaxBodySnapSize docs.
+	// bytes as part of the event stream. If this value is negative,
+	// we use math.MaxInt64. If the value is zero, we use a
+	// reasonable large value. Otherwise, we'll use this value.
 	MaxBodySnapSize int64
 
 	// LookupHost allows to override the host lookup for all the request

--- a/modelx/modelx.go
+++ b/modelx/modelx.go
@@ -401,8 +401,10 @@ type HTTPRoundTripDoneEvent struct {
 	// ResponseStatusCode contains the HTTP status code if error is nil.
 	ResponseStatusCode int64
 
-	// SnapSize is the size of the bodies snapshot
-	SnapSize int64
+	// MaxBodySnapSize is the maximum size of the bodies snapshot. If this
+	// value is negative, we use math.MaxInt64. If the value is zero, we
+	// use a reasonable large value. Otherwise, we'll use this value.
+	MaxBodySnapSize int64
 
 	// TransactionID is the identifier of this transaction
 	TransactionID int64
@@ -691,6 +693,14 @@ type MeasurementRoot struct {
 
 	// Handler is the handler that will handle events.
 	Handler Handler
+
+	// MaxBodySnapSize is the maximum size after which we'll stop
+	// reading request and response bodies. They will of course
+	// be fully transmitted, but we'll save only MaxBodySnapSize
+	// bytes as part of the event stream.
+	//
+	// See also HTTPRoundTripDoneEvent.MaxBodySnapSize docs.
+	MaxBodySnapSize int64
 
 	// LookupHost allows to override the host lookup for all the request
 	// and dials that use this measurement root.

--- a/x/logger/logger.go
+++ b/x/logger/logger.go
@@ -177,6 +177,7 @@ func (h *Handler) OnMeasurement(m modelx.Measurement) {
 		h.logger.WithFields(log.Fields{
 			"elapsed":            m.HTTPRoundTripDone.DurationSinceBeginning,
 			"error":              m.HTTPRoundTripDone.Error,
+			"maxBodySnapSize":    m.HTTPRoundTripDone.MaxBodySnapSize,
 			"requestBody":        stringifyBody(m.HTTPRoundTripDone.RequestBodySnap),
 			"requestMethod":      m.HTTPRoundTripDone.RequestMethod,
 			"requestHeaders":     m.HTTPRoundTripDone.RequestHeaders,
@@ -184,7 +185,6 @@ func (h *Handler) OnMeasurement(m modelx.Measurement) {
 			"responseBody":       stringifyBody(m.HTTPRoundTripDone.ResponseBodySnap),
 			"responseHeaders":    m.HTTPRoundTripDone.ResponseHeaders,
 			"responseStatusCode": m.HTTPRoundTripDone.ResponseStatusCode,
-			"snapSize":           m.HTTPRoundTripDone.SnapSize,
 			"transactionID":      m.HTTPRoundTripDone.TransactionID,
 		}).Debug("http: round trip done")
 	}


### PR DESCRIPTION
If the user explicitly requests for unbounded bodies, then satisfy
this request, but from now on, the default is snapped at 1<<20.

Should address all OONI needs and be safer.