### PR TITLE
README.md: slightly change the wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ results of HTTP and network events.
 https://godoc.org/github.com/ooni/netx)
 
 Implements `net.Dialer` and `net.Resolver` replacements that saves the
-timing and results of network events.
+timing and the details of network events.
 
 ### Other packages
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ TLS handshake for DoT and DoH).
 https://godoc.org/github.com/ooni/netx/modelx)
 
 The base package, that defines everything that other packages
-will use. Among others, it defines the measurement model.
+will use, and chiefly the measurement model.
 
 ### github.com/ooni/netx/httpx
 
 [![GoDoc](https://godoc.org/github.com/ooni/netx/httpx?status.svg)](
 https://godoc.org/github.com/ooni/netx/httpx)
 
-Implements a replacement for `http.Client` that saves the timing and
+Implements a `http.Client` replacement that saves the timing and
 results of HTTP and network events.
 
 ### github.com/ooni/netx
@@ -45,8 +45,8 @@ results of HTTP and network events.
 [![GoDoc](https://godoc.org/github.com/ooni/netx?status.svg)](
 https://godoc.org/github.com/ooni/netx)
 
-Implements a replacement for `net.Dialer` that saves the timing and
-results of network events and a replacement for `net.Resolver`.
+Implements `net.Dialer` and `net.Resolver` replacements that saves the
+timing and results of network events.
 
 ### Other packages
 


### PR DESCRIPTION
The main reason why I opened this PR was to understand why we have five checks rather than three, and specifically two duplicate Travis checks. The reason is the one explained in https://github.com/travis-ci/travis-ci/issues/10152#issuecomment-424703023, and the fix is to go to https://travis-ci.org/organizations/ooni/repositories and manually disable netx.

That said, I also like the new wording slightly more.