### PR TITLE
model: publish SNI when we force it being different

### DIFF
--- a/internal/dialer/tlsdialer/tlsdialer.go
+++ b/internal/dialer/tlsdialer/tlsdialer.go
@@ -77,6 +77,7 @@ func (d *TLSDialer) DialTLSContext(
 		TLSHandshakeStart: &modelx.TLSHandshakeStartEvent{
 			ConnID:                 connID,
 			DurationSinceBeginning: time.Now().Sub(root.Beginning),
+			SNI:                    config.ServerName,
 		},
 	})
 	err = tlsconn.Handshake()

--- a/modelx/modelx.go
+++ b/modelx/modelx.go
@@ -573,6 +573,9 @@ type TLSHandshakeStartEvent struct {
 	// the time configured as the "zero" time.
 	DurationSinceBeginning time.Duration
 
+	// SNI is the SNI used when we force a specific SNI.
+	SNI string
+
 	// TransactionID is the ID of the transaction that started
 	// this TLS handshake, or zero if we don't know it. Typically,
 	// it is zero for explicit dials, and it's nonzero instead

--- a/x/logger/logger.go
+++ b/x/logger/logger.go
@@ -116,6 +116,7 @@ func (h *Handler) OnMeasurement(m modelx.Measurement) {
 		h.logger.WithFields(log.Fields{
 			"connID":        m.TLSHandshakeStart.ConnID,
 			"elapsed":       m.TLSHandshakeStart.DurationSinceBeginning,
+			"sni":           m.TLSHandshakeStart.SNI,
 			"transactionID": m.TLSHandshakeStart.TransactionID,
 		}).Debug("tls: start handshake")
 	}


### PR DESCRIPTION
This helps with analysing tests for SNI triggered RST injection.