### PR TITLE
cURL like logs, support Accept{,-Language}, disable auto-followup for bogons

### DIFF
--- a/internal/errwrapper/errwrapper.go
+++ b/internal/errwrapper/errwrapper.go
@@ -10,9 +10,6 @@ import (
 	"github.com/ooni/netx/modelx"
 )
 
-// ErrDNSBogon indicates that we found a bogon address
-var ErrDNSBogon = errors.New("dns: detected bogon address")
-
 // SafeErrWrapperBuilder contains a builder for modelx.ErrWrapper that
 // is safe, i.e., behaves correctly when the error is nil.
 type SafeErrWrapperBuilder struct {
@@ -57,7 +54,7 @@ func toFailureString(err error) string {
 		return errwrapper.Error() // we've already wrapped it
 	}
 
-	if errors.Is(err, ErrDNSBogon) {
+	if errors.Is(err, modelx.ErrDNSBogon) {
 		return "dns_bogon_error" // not in MK
 	}
 

--- a/internal/errwrapper/errwrapper_test.go
+++ b/internal/errwrapper/errwrapper_test.go
@@ -47,8 +47,8 @@ func TestToFailureString(t *testing.T) {
 			t.Fatal("unexpected result")
 		}
 	})
-	t.Run("for errwrapper.ErrDNSBogon", func(t *testing.T) {
-		if toFailureString(ErrDNSBogon) != "dns_bogon_error" {
+	t.Run("for modelx.ErrDNSBogon", func(t *testing.T) {
+		if toFailureString(modelx.ErrDNSBogon) != "dns_bogon_error" {
 			t.Fatal("unexpected result")
 		}
 	})

--- a/internal/httptransport/tracetripper/tracetripper.go
+++ b/internal/httptransport/tracetripper/tracetripper.go
@@ -192,7 +192,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			root.Handler.OnMeasurement(modelx.Measurement{
 				HTTPRequestHeadersDone: &modelx.HTTPRequestHeadersDoneEvent{
 					DurationSinceBeginning: time.Now().Sub(root.Beginning),
+					Headers:                requestHeaders, // [*]
+					Method:                 req.Method,     // [*]
 					TransactionID:          tid,
+					URL:                    req.URL, // [*]
 				},
 			})
 		},
@@ -258,6 +261,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if resp != nil {
 		event.ResponseHeaders = resp.Header
 		event.ResponseStatusCode = int64(resp.StatusCode)
+		event.ResponseProto = resp.Proto
 		// Save a snapshot of the response body
 		var data []byte
 		data, err = readSnap(&resp.Body, snapSize, t.readAll)

--- a/internal/resolver/parentresolver/parentresolver_test.go
+++ b/internal/resolver/parentresolver/parentresolver_test.go
@@ -80,8 +80,9 @@ func TestLookupHostBogon(t *testing.T) {
 	handler := new(emitterchecker)
 	ctx := modelx.WithMeasurementRoot(
 		context.Background(), &modelx.MeasurementRoot{
-			Beginning: time.Now(),
-			Handler:   handler,
+			Beginning:   time.Now(),
+			ErrDNSBogon: modelx.ErrDNSBogon,
+			Handler:     handler,
 		})
 	addrs, err := client.LookupHost(ctx, "localhost")
 	if err == nil {

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -6,7 +6,9 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/modelx"
 )
 
@@ -31,7 +33,13 @@ func testresolverquick(t *testing.T, resolver modelx.DNSResolver) {
 
 func TestIntegrationDetectBogon(t *testing.T) {
 	resolver := NewResolverSystem()
-	addrs, err := resolver.LookupHost(context.Background(), "localhost")
+	ctx := modelx.WithMeasurementRoot(
+		context.Background(), &modelx.MeasurementRoot{
+			Beginning:   time.Now(),
+			ErrDNSBogon: modelx.ErrDNSBogon,
+			Handler:     handlers.NoHandler,
+		})
+	addrs, err := resolver.LookupHost(ctx, "localhost")
 	if err == nil {
 		t.Fatal("expected an error here")
 	}

--- a/modelx/modelx.go
+++ b/modelx/modelx.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/miekg/dns"
@@ -323,8 +324,23 @@ type HTTPRequestHeadersDoneEvent struct {
 	// the time configured as the "zero" time.
 	DurationSinceBeginning time.Duration
 
+	// Headers contain the original request headers. This is included
+	// here to make this event actionable without needing to join it with
+	// other events, i.e., to simplify logging.
+	Headers http.Header
+
+	// Method is the original request method. This is here
+	// for the same reason of Headers.
+	Method string
+
 	// TransactionID is the identifier of this transaction
 	TransactionID int64
+
+	// URL is the original request URL. This is here
+	// for the same reason of Headers. We use an object
+	// rather than a string, because here you want to
+	// use specific subfields directly for logging.
+	URL *url.URL
 }
 
 // HTTPRequestDoneEvent is emitted when we have sent the request
@@ -398,6 +414,9 @@ type HTTPRoundTripDoneEvent struct {
 
 	// ResponseHeaders contains the response headers if error is nil.
 	ResponseHeaders http.Header
+
+	// ResponseProto contains the response protocol
+	ResponseProto string
 
 	// ResponseStatusCode contains the HTTP status code if error is nil.
 	ResponseStatusCode int64

--- a/modelx/modelx.go
+++ b/modelx/modelx.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"net"
 	"net/http"
 	"time"
@@ -682,6 +683,11 @@ type TLSDialer interface {
 	DialTLSContext(ctx context.Context, network, address string) (net.Conn, error)
 }
 
+// ErrDNSBogon indicates that we found a bogon address. This is the
+// correct value with which to initialize MeasurementRoot.ErrDNSBogon
+// to tell this library to return an error when a bogon is found.
+var ErrDNSBogon = errors.New("dns: detected bogon address")
+
 // MeasurementRoot is the measurement root.
 //
 // If you attach this to a context, we'll use it rather than using
@@ -691,6 +697,16 @@ type TLSDialer interface {
 type MeasurementRoot struct {
 	// Beginning is the "zero" used to compute the elapsed time.
 	Beginning time.Time
+
+	// ErrDNSBogon is the kind of error that you would like this
+	// library to return when a bogon IP address is found. The
+	// default value, nil, causes this library to only record the
+	// occurrence of such bogon in the scoreboard, but does not
+	// otherwise cause any failure. Setting this field to non-nil
+	// error causes the library instead fail when a bogon has
+	// been detected. The best value with which to initialize this
+	// field is the ErrDNSBogon variable in this package.
+	ErrDNSBogon error
 
 	// Handler is the handler that will handle events.
 	Handler Handler

--- a/x/logger/logger_test.go
+++ b/x/logger/logger_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/discard"
 	"github.com/ooni/netx/httpx"
-	"github.com/ooni/netx/modelx"
 )
 
 func TestIntegration(t *testing.T) {
@@ -27,11 +26,4 @@ func TestIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 	client.HTTPClient.CloseIdleConnections()
-}
-
-func TestExtension(t *testing.T) {
-	logger := NewHandler(log.Log)
-	logger.OnMeasurement(modelx.Measurement{
-		Extension: &modelx.ExtensionEvent{},
-	})
 }

--- a/x/porcelain/porcelain.go
+++ b/x/porcelain/porcelain.go
@@ -218,6 +218,8 @@ func DNSLookup(
 
 // HTTPDoConfig contains HTTPDo settings.
 type HTTPDoConfig struct {
+	Accept           string
+	AcceptLanguage   string
 	Body             []byte
 	DNSServerAddress string
 	DNSServerNetwork string
@@ -278,6 +280,12 @@ func HTTPDo(
 	req, err := http.NewRequest(config.Method, config.URL, nil)
 	if err != nil {
 		return nil, err
+	}
+	if config.Accept != "" {
+		req.Header.Set("Accept", config.Accept)
+	}
+	if config.AcceptLanguage != "" {
+		req.Header.Set("Accept-Language", config.AcceptLanguage)
 	}
 	req.Header.Set("User-Agent", config.UserAgent)
 	req = req.WithContext(ctx)

--- a/x/porcelain/porcelain_test.go
+++ b/x/porcelain/porcelain_test.go
@@ -86,7 +86,9 @@ func TestIntegrationDNSLookupUnknownDNS(t *testing.T) {
 func TestIntegrationHTTPDoGood(t *testing.T) {
 	ctx := context.Background()
 	results, err := HTTPDo(ctx, HTTPDoConfig{
-		URL: "http://ooni.io",
+		Accept:         "*/*",
+		AcceptLanguage: "en",
+		URL:            "http://ooni.io",
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR contains three small patches from my development branch:

1. disable auto-followup for bogons, as it may be problematic in some corner cases

2. support Accept and Accept-Language headers

3. emit cURL like logs because people is used to them (including me)