### PR TITLE
Make sure regress tests are all green on travis

### DIFF
--- a/internal/resolver/ooniresolver/ooniresolver_test.go
+++ b/internal/resolver/ooniresolver/ooniresolver_test.go
@@ -49,7 +49,9 @@ func TestLookupCNAME(t *testing.T) {
 
 func TestLookupHostWithRetry(t *testing.T) {
 	// Because there is no server there, if there is no DNS injection
-	// then we are going to see several timeouts.
+	// then we are going to see several timeouts. However, this test is
+	// going to fail if you're under permanent DNS hijacking, which is
+	// what happens with Vodafone "Rete Sicura" (on by default) in Italy.
 	client := New(dnsoverudp.NewTransport(
 		&net.Dialer{}, "www.example.com:53",
 	))

--- a/x/porcelain/porcelain_test.go
+++ b/x/porcelain/porcelain_test.go
@@ -241,7 +241,7 @@ func TestIntegrationBodySnapSizes(t *testing.T) {
 	)
 	ctx := context.Background()
 	results := HTTPDo(ctx, HTTPDoConfig{
-		URL:                     "https://ooni.io",
+		URL:                     "https://ooni.org",
 		MaxEventsBodySnapSize:   maxEventsBodySnapSize,
 		MaxResponseBodySnapSize: maxResponseBodySnapSize,
 	})


### PR DESCRIPTION
Prompted by failures in #144. While there, mention with documentation which tests are gonna fail if you are using DNS hijacking ISP settings like Vodafone Italia does by default.