### PR TITLE
Detach porcelain from netx/internal

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -426,8 +426,3 @@ We will be likely be adding more automation. The mechanism
 to communicate these information is called `scoreboard`
 and is currenly in the `github.com/ooni/netx/x` package in
 which we keep experimental extensions.
-
-## Running OONI measurements
-
-We have syntactic sugar for running OONI measurements as
-part of the `github.com/ooni/netx/x` package.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ooni/netx
 
-go 1.11
+go 1.13
 
 require (
 	github.com/apex/log v1.1.1

--- a/internal/httptransport/tracetripper/tracetripper.go
+++ b/internal/httptransport/tracetripper/tracetripper.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"io"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"net/http/httptrace"
 	"sync"
@@ -19,18 +18,6 @@ import (
 	"github.com/ooni/netx/internal/transactionid"
 	"github.com/ooni/netx/modelx"
 )
-
-const defaultBodySnapSize int64 = 1 << 20
-
-// ComputeBodySnapSize computes the body snap size
-func ComputeBodySnapSize(snapSize int64) int64 {
-	if snapSize < 0 {
-		snapSize = math.MaxInt64
-	} else if snapSize == 0 {
-		snapSize = defaultBodySnapSize
-	}
-	return snapSize
-}
 
 // Transport performs single HTTP transactions.
 type Transport struct {
@@ -106,7 +93,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		requestBody      []byte
 		requestHeaders   = http.Header{}
 		requestHeadersMu sync.Mutex
-		snapSize         = ComputeBodySnapSize(root.MaxBodySnapSize)
+		snapSize         = modelx.ComputeBodySnapSize(root.MaxBodySnapSize)
 	)
 
 	// Save a snapshot of the request body

--- a/internal/httptransport/tracetripper/tracetripper_test.go
+++ b/internal/httptransport/tracetripper/tracetripper_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"net/http/httptrace"
 	"sync"
@@ -269,17 +268,5 @@ func TestIntegrationWithReadAllFailingForBody(t *testing.T) {
 	// Finally, make sure we got something that makes sense
 	if len(handler.roundTrips) != 0 {
 		t.Fatal("more round trips than expected")
-	}
-}
-
-func TestUnitComputeBodySnapSize(t *testing.T) {
-	if ComputeBodySnapSize(-1) != math.MaxInt64 {
-		t.Fatal("unexpected result")
-	}
-	if ComputeBodySnapSize(0) != defaultBodySnapSize {
-		t.Fatal("unexpected result")
-	}
-	if ComputeBodySnapSize(127) != 127 {
-		t.Fatal("unexpected result")
 	}
 }

--- a/modelx/modelx.go
+++ b/modelx/modelx.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -370,6 +371,20 @@ type HTTPResponseStartEvent struct {
 
 	// TransactionID is the identifier of this transaction
 	TransactionID int64
+}
+
+const defaultBodySnapSize int64 = 1 << 20
+
+// ComputeBodySnapSize computes the body snap size. If snapSize is negative
+// we return MaxInt64. If it's zero we return the default snap size. Otherwise
+// the value of snapSize is returned.
+func ComputeBodySnapSize(snapSize int64) int64 {
+	if snapSize < 0 {
+		snapSize = math.MaxInt64
+	} else if snapSize == 0 {
+		snapSize = defaultBodySnapSize
+	}
+	return snapSize
 }
 
 // HTTPRoundTripDoneEvent is emitted at the end of the round trip. Either

--- a/modelx/modelx_test.go
+++ b/modelx/modelx_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"math"
 	"testing"
 	"time"
 )
@@ -67,5 +68,17 @@ func TestErrWrapperPublicAPI(t *testing.T) {
 	}
 	if wrapper.Unwrap() != child {
 		t.Fatal("The Unwrap() method is misbehaving")
+	}
+}
+
+func TestUnitComputeBodySnapSize(t *testing.T) {
+	if ComputeBodySnapSize(-1) != math.MaxInt64 {
+		t.Fatal("unexpected result")
+	}
+	if ComputeBodySnapSize(0) != defaultBodySnapSize {
+		t.Fatal("unexpected result")
+	}
+	if ComputeBodySnapSize(127) != 127 {
+		t.Fatal("unexpected result")
 	}
 }

--- a/x/logger/logger.go
+++ b/x/logger/logger.go
@@ -1,4 +1,7 @@
-// Package logger is a handler that emits logs
+// Package logger is a handler that emits logs.
+//
+// This is an experimental package and may change/disappear
+// at any time without any documentation.
 package logger
 
 import (

--- a/x/porcelain/porcelain.go
+++ b/x/porcelain/porcelain.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/httpx"
 	"github.com/ooni/netx/internal/errwrapper"
-	"github.com/ooni/netx/internal/httptransport/tracetripper"
 	"github.com/ooni/netx/modelx"
 	"github.com/ooni/netx/x/scoreboard"
 )
@@ -311,7 +310,7 @@ func HTTPDo(
 		mu.Unlock()
 		defer resp.Body.Close()
 		reader := io.LimitReader(
-			resp.Body, tracetripper.ComputeBodySnapSize(
+			resp.Body, modelx.ComputeBodySnapSize(
 				config.MaxResponseBodySnapSize,
 			),
 		)

--- a/x/porcelain/porcelain.go
+++ b/x/porcelain/porcelain.go
@@ -1,9 +1,7 @@
 // Package porcelain contains useful high level functionality.
 //
-// This is the main package used by ooni/probe-engine. The objective
-// of this package is to make things simple in probe-engine.
-//
-// Also, this is currently experimental. So, no API promises here.
+// This is an experimental package and may change/disappear
+// at any time without any documentation.
 package porcelain
 
 import (

--- a/x/porcelain/porcelain.go
+++ b/x/porcelain/porcelain.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ooni/netx"
 	"github.com/ooni/netx/handlers"
 	"github.com/ooni/netx/httpx"
-	"github.com/ooni/netx/internal/errwrapper"
 	"github.com/ooni/netx/modelx"
 	"github.com/ooni/netx/x/scoreboard"
 )
@@ -319,13 +318,6 @@ func HTTPDo(
 		results.BodySnap, results.Error = data, err
 		mu.Unlock()
 	})
-	// For safety wrap the error as "http_round_trip" but this
-	// will only be used if the error chain does not contain any
-	// other major operation failure. See modelx.ErrWrapper.
-	results.Error = errwrapper.SafeErrWrapperBuilder{
-		Error:     results.Error,
-		Operation: "http_round_trip",
-	}.MaybeBuild()
 	results.TestKeys.Scoreboard = &root.X.Scoreboard
 	results.SNIBlockingFollowup = maybeRunTLSChecks(
 		origCtx, config.Handler, &root.X,

--- a/x/porcelain/porcelain_test.go
+++ b/x/porcelain/porcelain_test.go
@@ -99,22 +99,6 @@ func TestIntegrationHTTPDoGood(t *testing.T) {
 	}
 }
 
-func TestIntegrationHTTPDoCancellation(t *testing.T) {
-	ctx, cancel := context.WithTimeout(
-		context.Background(), time.Microsecond,
-	)
-	defer cancel()
-	results := HTTPDo(ctx, HTTPDoConfig{
-		URL: "http://ooni.io",
-	})
-	if results.Error == nil {
-		t.Fatal("expected an error here")
-	}
-	if results.Error.Error() != "generic_timeout_error" {
-		t.Fatal("not the error we expected")
-	}
-}
-
 func TestIntegrationHTTPDoUnknownDNS(t *testing.T) {
 	ctx := context.Background()
 	results := HTTPDo(ctx, HTTPDoConfig{

--- a/x/scoreboard/scoreboard.go
+++ b/x/scoreboard/scoreboard.go
@@ -1,6 +1,7 @@
 // Package scoreboard contains the measurements scoreboard.
 //
-// This is currently experimental code.
+// This is an experimental package and may change/disappear
+// at any time without any documentation.
 package scoreboard
 
 import (


### PR DESCRIPTION
This is yak shaving as part of https://github.com/ooni/probe-engine/issues/2. Specifically, this diff refactors the code such that `netx/x/{logger,porcelain}` does not depend on `netx/internal`.

Each individual commit contains its own short rationale.

On a broader level, this diff is related to discussions I had with @FedericoCeratto concerning unifying `netx` and `probe-engine` to reduce complexity. I have determined that this won't happen because:

1. I am using `netx` also in `jafar` and it makes sense therefore to keep `netx` independent

2. the `netx` API described in `DESIGN.md` is not poised to change because it is based on the standard library API, hence we should keep it stable

Thus, I can see how occasionally we'll make the data model richer, or apply fixes, but I see low coupling between the `DESIGN.md` API and `probe-engine`.

OTOH, the coupling is very high for two packages in `x`: `porcelain` and `logger`. So, the right approach is to fork these two packages in `probe-engine` and develop them in there. This PR is precisely aiming at making sure that we can fork them. I also considered deleting them but, since they are clearly marked as experimental, it's also fine to keep them.