### PR TITLE
netx: allow skipping certificate verification

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 | Author       | Simone Basso |
 |--------------|--------------|
-| Last-Updated | 2019-11-02   |
+| Last-Updated | 2020-01-09   |
 | Status       | approved     |
 
 ## Introduction
@@ -316,15 +316,17 @@ d := netx.NewDialerWithoutHandler()
 d.SetResolver(resolver)
 d.ForceSpecificSNI("www.kernel.org")
 d.SetCABundle("/etc/ssl/cert.pem")
+d.ForceSkipVerify()
 var dialer modelx.Dialer = d
 // now use dialer
 ```
 
 where `SetResolver` allows you to change the resolver,
 `ForceSpecificSNI` forces the TLS dials to use such SNI
-instead of using the provided domain, and `SetCABundle`
-allows to set a specific CA bundle. All these funcs
-MUST be invoked before using the dialer.
+instead of using the provided domain, `SetCABundle`
+allows to set a specific CA bundle, and `ForceSkipVerify`
+allows to disable certificate verification. All these funcs
+MUST NOT be invoked once you're using the dialer.
 
 The `github.com/ooni/netx/httpx` package MUST contain
 code so that we can do:
@@ -336,6 +338,7 @@ t := httpx.NewHTTPTransportWithProxyFunc(
 t.SetResolver(resolver)
 t.ForceSpecificSNI("www.kernel.org")
 t.SetCABundle("/etc/ssl/cert.pem")
+t.ForceSkipVerify()
 var transport http.RoundTripper = t
 // now use transport
 ```

--- a/cmd/httpdo/main.go
+++ b/cmd/httpdo/main.go
@@ -20,6 +20,7 @@ func main() {
 		flagDNSAddress   = flag.String("httpdo-dns-address", "", "Transport dependent address")
 		flagDNSTransport = flag.String("httpdo-dns-transport", "system", "DNS transport")
 		flagMethod       = flag.String("httpdo-method", "GET", "Method to use")
+		flagNoVerify     = flag.Bool("httpdo-no-verify", false, "Skip TLS verification")
 		flagTimeout      = flag.Duration("httpdo-timeout", 60*time.Second, "Overall timeout")
 		flagURL          = flag.String("httpdo-url", "https://ooni.io", "URL to use")
 	)
@@ -31,11 +32,12 @@ func main() {
 	)
 	defer cancel()
 	results := porcelain.HTTPDo(ctx, porcelain.HTTPDoConfig{
-		DNSServerAddress: *flagDNSAddress,
-		DNSServerNetwork: *flagDNSTransport,
-		Method:           *flagMethod,
-		Handler:          logger.NewHandler(log.Log),
-		URL:              *flagURL,
+		DNSServerAddress:   *flagDNSAddress,
+		DNSServerNetwork:   *flagDNSTransport,
+		Method:             *flagMethod,
+		Handler:            logger.NewHandler(log.Log),
+		InsecureSkipVerify: *flagNoVerify,
+		URL:                *flagURL,
 	})
 	data, err := json.MarshalIndent(results, "", "  ")
 	rtx.Must(err, "json.Marshal failed")

--- a/httpx/httpx.go
+++ b/httpx/httpx.go
@@ -83,6 +83,11 @@ func (t *Transport) ForceSpecificSNI(sni string) error {
 	return t.dialer.ForceSpecificSNI(sni)
 }
 
+// ForceSkipVerify forces to skip certificate verification
+func (t *Transport) ForceSkipVerify() error {
+	return t.dialer.ForceSkipVerify()
+}
+
 // Client is a replacement for http.Client.
 type Client struct {
 	// HTTPClient is the underlying client. Pass this client to existing code
@@ -142,4 +147,9 @@ func (c *Client) SetCABundle(path string) error {
 // ForceSpecificSNI forces using a specific SNI.
 func (c *Client) ForceSpecificSNI(sni string) error {
 	return c.Transport.ForceSpecificSNI(sni)
+}
+
+// ForceSkipVerify forces to skip certificate verification
+func (c *Client) ForceSkipVerify() error {
+	return c.Transport.ForceSkipVerify()
 }

--- a/httpx/httpx_test.go
+++ b/httpx/httpx_test.go
@@ -47,7 +47,7 @@ func TestIntegrationSetResolver(t *testing.T) {
 	}
 }
 func TestSetCABundle(t *testing.T) {
-	client := httpx.NewClient(handlers.NoHandler)
+	client := httpx.NewClientWithoutProxy(handlers.NoHandler)
 	err := client.SetCABundle("../testdata/cacert.pem")
 	if err != nil {
 		t.Fatal(err)
@@ -55,7 +55,7 @@ func TestSetCABundle(t *testing.T) {
 }
 
 func TestForceSpecificSNI(t *testing.T) {
-	client := httpx.NewClient(handlers.NoHandler)
+	client := httpx.NewClientWithoutProxy(handlers.NoHandler)
 	err := client.ForceSpecificSNI("www.facebook.com")
 	if err != nil {
 		t.Fatal(err)
@@ -69,6 +69,18 @@ func TestForceSpecificSNI(t *testing.T) {
 	t.Log(err)
 	if resp != nil {
 		t.Fatal("expected a nil response here")
+	}
+}
+
+func TestForceSkipVerify(t *testing.T) {
+	client := httpx.NewClientWithoutProxy(handlers.NoHandler)
+	client.ForceSkipVerify()
+	resp, err := client.HTTPClient.Get("https://self-signed.badssl.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil {
+		t.Fatal("expected non nil response here")
 	}
 }
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -108,6 +108,12 @@ func (d *Dialer) ForceSpecificSNI(sni string) error {
 	return nil
 }
 
+// ForceSkipVerify forces to skip certificate verification
+func (d *Dialer) ForceSkipVerify() error {
+	d.TLSConfig.InsecureSkipVerify = true
+	return nil
+}
+
 // ConfigureDNS implements netx.Dialer.ConfigureDNS.
 func (d *Dialer) ConfigureDNS(network, address string) error {
 	r, err := NewResolver(d.Beginning, d.Handler, network, address)

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -45,6 +45,16 @@ func TestIntegrationDialTLS(t *testing.T) {
 	conn.Close()
 }
 
+func TestIntegrationDialTLSForceSkipVerify(t *testing.T) {
+	dialer := NewDialer(time.Now(), handlers.NoHandler)
+	dialer.ForceSkipVerify()
+	conn, err := dialer.DialTLS("tcp", "self-signed.badssl.com:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+}
+
 func TestIntegrationDialInvalidAddress(t *testing.T) {
 	dialer := NewDialer(time.Now(), handlers.NoHandler)
 	conn, err := dialer.Dial("tcp", "www.google.com")

--- a/netx.go
+++ b/netx.go
@@ -135,6 +135,11 @@ func (d *Dialer) ForceSpecificSNI(sni string) error {
 	return d.dialer.ForceSpecificSNI(sni)
 }
 
+// ForceSkipVerify forces to skip certificate verification
+func (d *Dialer) ForceSkipVerify() error {
+	return d.dialer.ForceSkipVerify()
+}
+
 // ChainResolvers chains a primary and a secondary resolver such that
 // we can fallback to the secondary if primary is broken.
 func ChainResolvers(primary, secondary modelx.DNSResolver) modelx.DNSResolver {

--- a/netx_test.go
+++ b/netx_test.go
@@ -129,6 +129,16 @@ func TestForceSpecificSNI(t *testing.T) {
 	}
 }
 
+func TestIntegrationDialTLSForceSkipVerify(t *testing.T) {
+	dialer := netx.NewDialer(handlers.NoHandler)
+	dialer.ForceSkipVerify()
+	conn, err := dialer.DialTLS("tcp", "self-signed.badssl.com:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+}
+
 func TestChainResolvers(t *testing.T) {
 	fallback, err := netx.NewResolver(handlers.NoHandler, "udp", "1.1.1.1:53")
 	if err != nil {

--- a/x/logger/logger.go
+++ b/x/logger/logger.go
@@ -136,7 +136,7 @@ func (h *Handler) OnMeasurement(m modelx.Measurement) {
 			m.HTTPResponseStart.TransactionID,
 		)
 	}
-	if m.HTTPRoundTripDone != nil {
+	if m.HTTPRoundTripDone != nil && m.HTTPRoundTripDone.Error == nil {
 		h.logger.Debugf(
 			"[httpTxID: %d] < %s %d %s",
 			m.HTTPRoundTripDone.TransactionID,

--- a/x/porcelain/porcelain.go
+++ b/x/porcelain/porcelain.go
@@ -215,16 +215,17 @@ func DNSLookup(
 
 // HTTPDoConfig contains HTTPDo settings.
 type HTTPDoConfig struct {
-	Accept           string
-	AcceptLanguage   string
-	Body             []byte
-	DNSServerAddress string
-	DNSServerNetwork string
-	Handler          modelx.Handler
-	Method           string
-	ProxyFunc        func(*http.Request) (*url.URL, error)
-	URL              string
-	UserAgent        string
+	Accept             string
+	AcceptLanguage     string
+	Body               []byte
+	DNSServerAddress   string
+	DNSServerNetwork   string
+	Handler            modelx.Handler
+	InsecureSkipVerify bool
+	Method             string
+	ProxyFunc          func(*http.Request) (*url.URL, error)
+	URL                string
+	UserAgent          string
 
 	// MaxEventsBodySnapSize controls the snap size that
 	// we're using for bodies returned as modelx.Measurement.
@@ -278,6 +279,9 @@ func HTTPDo(
 		return results
 	}
 	client.SetResolver(resolver)
+	if config.InsecureSkipVerify {
+		client.ForceSkipVerify()
+	}
 	// TODO(bassosimone): implement sending body
 	req, err := http.NewRequest(config.Method, config.URL, nil)
 	if err != nil {

--- a/x/porcelain/porcelain_test.go
+++ b/x/porcelain/porcelain_test.go
@@ -130,6 +130,17 @@ func TestIntegrationHTTPDoBadURL(t *testing.T) {
 	}
 }
 
+func TestIntegrationHTTPDoForceSkipVerify(t *testing.T) {
+	ctx := context.Background()
+	results := HTTPDo(ctx, HTTPDoConfig{
+		URL:                "https://self-signed.badssl.com/",
+		InsecureSkipVerify: true,
+	})
+	if results.Error != nil {
+		t.Fatal(results.Error)
+	}
+}
+
 func TestIntegrationTLSConnectGood(t *testing.T) {
 	ctx := context.Background()
 	results := TLSConnect(ctx, TLSConnectConfig{


### PR DESCRIPTION
Closes #127. Related to https://github.com/ooni/probe-engine/issues/2.