### PR TITLE
Clearly mention that netx is not maintained anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # github.com/ooni/netx
 
+⚠️: As of 2020-03-06, netx has been merged into ooni/probe-engine. You should
+import github.com/ooni/probe-engine/netx rather than github.com/ooni/netx. We
+thought it was easier to keep netx and probe-engine separate, but it turned
+out this was increasingly slowing us down, so we decided to merge them.
+
 ![Build Status](https://github.com/ooni/netx/workflows/Build/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/ooni/netx/badge.svg?branch=master)](https://coveralls.io/github/ooni/netx?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/ooni/netx)](https://goreportcard.com/report/github.com/ooni/netx)
 
 OONI extensions to the `net` and `net/http` packages. This code is

--- a/modelx/modelx.go
+++ b/modelx/modelx.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"log"
 	"math"
 	"net"
 	"net/http"
@@ -804,4 +805,10 @@ func WithMeasurementRoot(
 	return context.WithValue(
 		ctx, measurementRootContextKey{}, root,
 	)
+}
+
+func init() {
+	log.Printf("⚠️⚠️⚠️⚠️ netx is not maintained anymore!")
+	log.Printf("⚠️⚠️⚠️⚠️ please import github.com/ooni/probe-engine/netx instead!")
+	time.Sleep(7*time.Second)
 }

--- a/netx.go
+++ b/netx.go
@@ -4,8 +4,8 @@
 // DialContext, and DialTLS. During its lifecycle this modified Dialer
 // will emit network level events on a channel.
 //
-// ⚠️: This package is deprecated. Use github.com/ooni/probe-engine/netx
-// as a drop-in replacement for this package.
+// ⚠️: This package is not maintained anymore. Use github.com/ooni/probe-engine/netx
+// as a drop-in replacement for github.com/ooni/netx.
 package netx
 
 import (

--- a/netx.go
+++ b/netx.go
@@ -3,6 +3,9 @@
 // This package provides a replacement for net.Dialer that can Dial,
 // DialContext, and DialTLS. During its lifecycle this modified Dialer
 // will emit network level events on a channel.
+//
+// ⚠️: This package is deprecated. Use github.com/ooni/probe-engine/netx
+// as a drop-in replacement for this package.
 package netx
 
 import (


### PR DESCRIPTION
Modify the documentation and the runtime behaviour to steer whom it
may concern to github.com/ooni/probe-engine/netx.